### PR TITLE
Docs: Fix grammar errors, typos, and broken markdown link

### DIFF
--- a/Institutions/Onboarding.md
+++ b/Institutions/Onboarding.md
@@ -4,7 +4,7 @@ Most steps depend on the status of the Institution in Airtable 'Institutions (Fo
 
 ## Step 1: When a Form of Interest is Sent
 
-1. The institution fill up the form from 'Institutions (Form)' table.
+1. The institution fills up the form from 'Institutions (Form)' table.
 2. The form sends automatically an email to education@wordpressfoundation.org.
 3. Airtable sends an email to asking the student to book a meeting (the person of contact from the team responsible for the calendar link depends on the institution country, see Airtable 'Countries' and 'Team members' tables) or continue as discussed during the previous call (see [this template](https://secure.helpscout.net/settings/inbox/348355/saved-replies/3950163) as reference).
 

--- a/Institutions/Onboarding.md
+++ b/Institutions/Onboarding.md
@@ -6,7 +6,7 @@ Most steps depend on the status of the Institution in Airtable 'Institutions (Fo
 
 1. The institution fills up the form from 'Institutions (Form)' table.
 2. The form sends automatically an email to education@wordpressfoundation.org.
-3. Airtable sends an email to asking the student to book a meeting (the person of contact from the team responsible for the calendar link depends on the institution country, see Airtable 'Countries' and 'Team members' tables) or continue as discussed during the previous call (see [this template](https://secure.helpscout.net/settings/inbox/348355/saved-replies/3950163) as reference).
+3. Airtable sends an email asking the student to book a meeting (the person of contact from the team responsible for the calendar link depends on the institution country, see Airtable 'Countries' and 'Team members' tables) or continue as discussed during the previous call (see [this template](https://secure.helpscout.net/settings/inbox/348355/saved-replies/3950163) as reference).
 
 ## Step 2: When called scheduled
 

--- a/Mentors/Mentors onboarding.md
+++ b/Mentors/Mentors onboarding.md
@@ -4,7 +4,7 @@ Most steps depend on the status of the mentor in Airtable 'Mentors' table, so th
 
 ## Step 1: When a Form of Interest is Sent
 
-1. The mentor fill up the form.
+1. The mentor fills up the form.
 2. 'Status' column needs to be **empty** at this point.
 3. Airtable sends the following email:
 

--- a/Mentors/Requirements to Become a WP Credits Mentor.md
+++ b/Mentors/Requirements to Become a WP Credits Mentor.md
@@ -2,7 +2,7 @@
 
 To join the WP Credits mentor group, candidates should:
 
-* Have a [wp.org](http://wp.org) account that shows both their [wp.org](http://wp.org) and slack names (if not, it means they are not in slack with that [wp.org](http://wp.org) account).   
+* Have a [wordpress.org](https://wordpress.org) account that shows both their [wordpress.org](https://wordpress.org) and slack names (if not, it means they are not in slack with that [wordpress.org](https://wordpress.org) account).   
 * Demonstrate alignment with the WordPress Foundation mission and values, including openness, collaboration, and respect.  
 * Show a positive and supportive attitude, being a good communicator and de-escalator in challenging situations.  
 * Be committed to student success, willing to dedicate at least 2 hours per week for mentoring and guidance.  

--- a/Pitch/[EN]General slides for Students.md
+++ b/Pitch/[EN]General slides for Students.md
@@ -200,7 +200,7 @@ Planning and coordination of digital projects.
 
 Automattic (WordPress.com, Jetpack, Woo) 
 
-Ellementor 
+Elementor 
 
 Weglot
 

--- a/Setup Documents/WP Credits - Operations - July 2025.md
+++ b/Setup Documents/WP Credits - Operations - July 2025.md
@@ -1,6 +1,5 @@
 ### **Contributors as of July 8 2025:**
-[
-Original Source](https://docs.google.com/document/d/1Z-zenWOoba5XeK1uiJQZ9rZDjwvv1lSH4j9B9fTw5RI/edit?tab=t.0#heading=h.tucxvai4g3ik)
+[Original Source](https://docs.google.com/document/d/1Z-zenWOoba5XeK1uiJQZ9rZDjwvv1lSH4j9B9fTw5RI/edit?tab=t.0#heading=h.tucxvai4g3ik)
 
 - Francesco Di Candia: 4/week   
 - Celi Garoe: 4/week   

--- a/Students/[Student Onboarding] Pisa.md
+++ b/Students/[Student Onboarding] Pisa.md
@@ -7,7 +7,7 @@ In all cases (EXCEPT the last 2 steps, 4th and 5th), the email has been conditio
 
 1. The student fills up the form and indicates **'Pisa University'** as their institution.
 2. 'Status' column needs to be **empty** at this point.
-3. Airtable sends an email to asking the student to book a meeting with Isotta (see [this template](https://secure.helpscout.net/settings/inbox/348355/saved-replies/3932399) as reference) with education@wordpressfoundation.org in copy. 
+3. Airtable sends an email asking the student to book a meeting with Isotta (see [this template](https://secure.helpscout.net/settings/inbox/348355/saved-replies/3932399) as reference) with education@wordpressfoundation.org in copy. 
 
 ## Step 2: After the Individual Meeting with Isotta
 

--- a/Students/[Student Onboarding] Pisa.md
+++ b/Students/[Student Onboarding] Pisa.md
@@ -5,7 +5,7 @@ In all cases (EXCEPT the last 2 steps, 4th and 5th), the email has been conditio
 
 ## Step 1: When a Form of Interest is Sent
 
-1. The student fill up the form and indicates **'Pisa University'** as their institution.
+1. The student fills up the form and indicates **'Pisa University'** as their institution.
 2. 'Status' column needs to be **empty** at this point.
 3. Airtable sends an email to asking the student to book a meeting with Isotta (see [this template](https://secure.helpscout.net/settings/inbox/348355/saved-replies/3932399) as reference) with education@wordpressfoundation.org in copy. 
 

--- a/Students/[Student Onboarding] Pisa.md
+++ b/Students/[Student Onboarding] Pisa.md
@@ -18,7 +18,7 @@ In all cases (EXCEPT the last 2 steps, 4th and 5th), the email has been conditio
 
 1. Students provide all needed information.
 2. Isotta prepares the agreement, sign it, and send it to the student and ask the student to sign it and to complete the signature round (tutor + send to the internship office).
-3. The students needs to confirm Isotta that the internship office has activated the project. 
+3. The student needs to confirm Isotta that the internship office has activated the project. 
 4. **When the project has been activated on the internship portal**, Isotta assigns the status **In Sensei** to the student's 'Status' column.
 
 ## Step 4: Mentor Assignment and Welcome Email to the Course 

--- a/Students/[Student Onboarding] Pisa.md
+++ b/Students/[Student Onboarding] Pisa.md
@@ -17,7 +17,7 @@ In all cases (EXCEPT the last 2 steps, 4th and 5th), the email has been conditio
 ## Step 3: Agreement Signature and Process
 
 1. Students provide all needed information.
-2. Isotta prepares the agreement, sign it, and send it to the student and ask the student to sign it and to complete the signature round (tutor + send to the internship office).
+2. Isotta prepares the agreement, signs it, and sends it to the student and asks the student to sign it and to complete the signature round (tutor + send to the internship office).
 3. The student needs to confirm Isotta that the internship office has activated the project. 
 4. **When the project has been activated on the internship portal**, Isotta assigns the status **In Sensei** to the student's 'Status' column.
 


### PR DESCRIPTION
## Description
This PR fixes various grammar errors, typos, and a broken markdown link across the documentation.

## Changes Made
- ✅ Changed HTTP links to HTTPS for wordpress.org
- ✅ Fixed "Ellementor" typo to "Elementor"
- ✅ Repaired broken markdown link in Operations July 2025 doc
- ✅ Fixed subject-verb agreement errors ("fill" → "fills", "students needs" → "student needs")
- ✅ Removed redundant "to" from "email to asking" → "email asking"
- ✅ Fixed verb forms for singular subject Isotta ("sign, send, ask" → "signs, sends, asks")

## Files Changed
- Institutions/Onboarding.md
- Mentors/Mentors onboarding.md
- Mentors/Requirements to Become a WP Credits Mentor.md
- Pitch/[EN]General slides for Students.md
- Setup Documents/WP Credits - Operations - July 2025.md
- Students/[Student Onboarding] Pisa.md