### PR TITLE
Add growth, feedback, and surface captured metrics

### DIFF
--- a/scripts/build_dashboard.py
+++ b/scripts/build_dashboard.py
@@ -10,7 +10,7 @@ import re
 import sys
 import time
 import requests
-from datetime import datetime
+from datetime import datetime, date
 from pathlib import Path
 
 # Configuration
@@ -27,6 +27,7 @@ TABLES = {
     "languages": "tblaxEPaabmlccHWn",
     "contribution_areas": "tblUBEXiS3QKUCXHf",
     "countries": "tbltB7GSRoTtSi4Ps",
+    "lessons": "tblGYMK0VpwMv3Bsy",
 }
 
 # Field IDs
@@ -39,6 +40,7 @@ FIELDS = {
         "wp_profile": "fld2rGCjmvTZg5DLg",
         "teams": "fldwPGiajTLTu1Vqi",
         "internship_end_date": "fldLwLXupWurmimc7",
+        "start_date_text": "fld2lU2ZvYSJx7Ncs",  # "May 1-15" etc. (month only, no year)
         "lessons": "fldE1rkXbTWJe8bBq",
         "mentor": "fldSBTwMgno8ecQ2X",
         # Learn course grade fields (non-empty = completed)
@@ -90,6 +92,14 @@ FIELDS = {
     },
     "countries": {
         "name": "fldtNqCEbpwdo9F2t",
+    },
+    # Lessons table holds the raw feedback-form submissions. Form 3 (the end-of-
+    # program form) is identified by any of these fields being populated; the
+    # record's createdTime is the Form 3 submission date.
+    "lessons": {
+        "f3_impact": "fld5idMQUwwpiljWf",
+        "f3_recommend": "fldKXSzK5zkGRe8OC",
+        "f3_keep": "fld4yTcZWUxdYiiiz",
     },
 }
 
@@ -237,6 +247,51 @@ def cohort_sort_key(cohort):
         return (9999, 99)
 
 
+MONTH_NAMES = {
+    m: i for i, m in enumerate(
+        ["January", "February", "March", "April", "May", "June", "July",
+         "August", "September", "October", "November", "December"], 1)
+}
+
+
+def parse_iso_date(s):
+    """Parse an ISO date or datetime string to a datetime.date (or None)."""
+    if not s or not isinstance(s, str) or len(s) < 10:
+        return None
+    try:
+        return date(int(s[0:4]), int(s[5:7]), int(s[8:10]))
+    except ValueError:
+        return None
+
+
+def parse_start_month(start_date_text):
+    """Get the month number (1-12) from a 'Start Date' value like 'May 1-15'."""
+    if not start_date_text:
+        return None
+    return MONTH_NAMES.get(str(start_date_text).split()[0])
+
+
+def infer_cohort_year(month, reference_date):
+    """Infer the year for a month-only cohort by picking the year whose
+    (year, month, 15) lands closest to the record's creation date.
+
+    'Start Date' carries no year, so we anchor it to when the record was created
+    (≈ when the student was onboarded). Becomes exact once a year-aware cohort
+    field exists in Airtable.
+    """
+    if not reference_date:
+        return None
+    return min(
+        (reference_date.year - 1, reference_date.year, reference_date.year + 1),
+        key=lambda y: abs((date(y, month, 15) - reference_date).days),
+    )
+
+
+def month_key(d):
+    """YYYY-MM bucket label for a date."""
+    return f"{d.year:04d}-{d.month:02d}" if d else None
+
+
 def get_field_value(record, field_id):
     """Safely get field value from Airtable record."""
     fields = record.get("fields", {})
@@ -341,6 +396,10 @@ def main():
     countries_records = fetch_all_records(
         BASE_ID, TABLES["countries"],
         list(FIELDS["countries"].values()), pat
+    )
+    lessons_records = fetch_all_records(
+        BASE_ID, TABLES["lessons"],
+        list(FIELDS["lessons"].values()), pat
     )
 
     print(f"Fetched {len(students_reports_records)} student reports", file=sys.stderr)
@@ -682,6 +741,71 @@ def main():
                 cname = countries_lookup[cid]["name"]
                 inst_countries[cname] = inst_countries.get(cname, 0) + 1
 
+    # --- Growth over time (monthly: students joining vs graduating) ---
+    # Form 3 (end-of-program) submission dates, keyed by Lessons record id.
+    form3_date_by_lesson = {}
+    for rec in lessons_records:
+        is_form3 = any(
+            get_field_value(rec, FIELDS["lessons"][f]) is not None
+            for f in ("f3_impact", "f3_recommend", "f3_keep")
+        )
+        if is_form3:
+            d = parse_iso_date(rec.get("createdTime"))
+            if d:
+                form3_date_by_lesson[rec["id"]] = d
+
+    # Statuses that count as having actually started (joined) the program.
+    JOINED_STATUS_KEYS = {
+        status_key(s) for s in [
+            "In Sensei", "In Sensei Self-onboarding", "In Sensei 50h",
+            "Pending graduation", "Graduate", "Dropped out", "Paused", "Fail",
+        ]
+    }
+    current_month = month_key(date.today())
+
+    joined_by_month = {}
+    graduated_by_month = {}
+    for rec in students_reports_records:
+        status_n = status_key(get_field_value(rec, FIELDS["students_reports"]["status"]))
+        if status_n not in JOINED_STATUS_KEYS:
+            continue
+        created = parse_iso_date(rec.get("createdTime"))
+
+        # Intake: month from "Start Date", year inferred from the creation date.
+        month = parse_start_month(get_field_value(rec, FIELDS["students_reports"]["start_date_text"]))
+        if month and created:
+            mk = f"{infer_cohort_year(month, created):04d}-{month:02d}"
+            if mk <= current_month:  # never show future sign-ups
+                joined_by_month[mk] = joined_by_month.get(mk, 0) + 1
+
+        # Graduations: "Graduated on" (future field) -> Form 3 date -> end date.
+        if status_n == GRADUATE_STATUS_KEY:
+            lesson_ids = get_field_value(rec, FIELDS["students_reports"]["lessons"]) or []
+            f3 = [form3_date_by_lesson[lid] for lid in lesson_ids if lid in form3_date_by_lesson]
+            grad_date = min(f3) if f3 else parse_iso_date(
+                get_field_value(rec, FIELDS["students_reports"]["internship_end_date"]))
+            mk = month_key(grad_date)
+            if mk and mk <= current_month:
+                graduated_by_month[mk] = graduated_by_month.get(mk, 0) + 1
+
+    # Continuous monthly series from first activity through the current month,
+    # filling empty months with zeros so the timeline has no gaps.
+    growth = {"months": [], "joined": [], "graduated": [], "cumulativeJoined": []}
+    all_months = set(joined_by_month) | set(graduated_by_month)
+    if all_months:
+        y, m = int(min(all_months)[:4]), int(min(all_months)[5:7])
+        cy, cm = int(current_month[:4]), int(current_month[5:7])
+        cum = 0
+        while (y, m) <= (cy, cm):
+            mk = f"{y:04d}-{m:02d}"
+            cum += joined_by_month.get(mk, 0)
+            growth["months"].append(mk)
+            growth["joined"].append(joined_by_month.get(mk, 0))
+            growth["graduated"].append(graduated_by_month.get(mk, 0))
+            growth["cumulativeJoined"].append(cum)
+            m = m + 1 if m < 12 else 1
+            y = y if m != 1 else y + 1
+
     # Build global stats
     global_stats = {
         "activeStudents": active_count,
@@ -715,6 +839,7 @@ def main():
         "translationTotals": translation_totals,
         "institutions": sorted(confirmed_institutions),
         "cohorts": cohorts_list,
+        "growth": growth,
         "students": students,
         "mentors": mentors,
     }

--- a/scripts/build_dashboard.py
+++ b/scripts/build_dashboard.py
@@ -28,6 +28,7 @@ TABLES = {
     "contribution_areas": "tblUBEXiS3QKUCXHf",
     "countries": "tbltB7GSRoTtSi4Ps",
     "lessons": "tblGYMK0VpwMv3Bsy",
+    "feedback": "tblx3TH6fp4edQJDm",
 }
 
 # Field IDs
@@ -100,6 +101,15 @@ FIELDS = {
         "f3_impact": "fld5idMQUwwpiljWf",
         "f3_recommend": "fldKXSzK5zkGRe8OC",
         "f3_keep": "fld4yTcZWUxdYiiiz",
+    },
+    # Student feedback (student-linked layer). Aggregate, experience-only.
+    "feedback": {
+        "ease": "fldn7M6U4xXurEgJ2",          # rating 1-5
+        "satisfaction": "fldJPTEix369b8NOw",   # rating 1-5
+        "impact": "fldxtEUsunNgjyKXV",         # rating 1-5
+        "confidence": "fldgnTd61qnS22D81",     # select (asked at the mid-program form)
+        "recommend": "fldZXbvOTIGad6r90",      # select: likely / neither / unlikely
+        "keep": "fld8RZMdCLYKtwcLN",           # select: likely / neither / unlikely
     },
 }
 
@@ -400,6 +410,10 @@ def main():
     lessons_records = fetch_all_records(
         BASE_ID, TABLES["lessons"],
         list(FIELDS["lessons"].values()), pat
+    )
+    feedback_records = fetch_all_records(
+        BASE_ID, TABLES["feedback"],
+        list(FIELDS["feedback"].values()), pat
     )
 
     print(f"Fetched {len(students_reports_records)} student reports", file=sys.stderr)
@@ -806,6 +820,47 @@ def main():
             m = m + 1 if m < 12 else 1
             y = y if m != 1 else y + 1
 
+    # --- Student feedback (aggregate, experience-only; no individuals) ---
+    def _rating_avg(field):
+        vals = [get_field_value(r, FIELDS["feedback"][field]) for r in feedback_records]
+        vals = [v for v in vals if isinstance(v, (int, float))]
+        return {"avg": round(sum(vals) / len(vals), 1), "n": len(vals)} if vals else {"avg": None, "n": 0}
+
+    def _pct_positive(field, positive_keys):
+        keys = [status_key(get_field_value(r, FIELDS["feedback"][field])) for r in feedback_records]
+        keys = [k for k in keys if k]
+        if not keys:
+            return {"pct": None, "n": 0}
+        pos = sum(1 for k in keys if k in positive_keys)
+        return {"pct": round(100 * pos / len(keys)), "n": len(keys)}
+
+    # Confidence distribution over the four real options (junk options ignored).
+    CONF_LABELS = {
+        "very confident": "Very confident",
+        "confident": "Confident",
+        "neutral": "Neutral",
+        "not very confident": "Not very confident",
+    }
+    conf_counts = {label: 0 for label in CONF_LABELS.values()}
+    conf_n = 0
+    for r in feedback_records:
+        k = status_key(get_field_value(r, FIELDS["feedback"]["confidence"]))
+        if k in CONF_LABELS:
+            conf_counts[CONF_LABELS[k]] += 1
+            conf_n += 1
+
+    feedback = {
+        "responses": len(feedback_records),
+        "ratings": {
+            "ease": _rating_avg("ease"),
+            "satisfaction": _rating_avg("satisfaction"),
+            "impact": _rating_avg("impact"),
+        },
+        "recommend": _pct_positive("recommend", {"likely"}),
+        "keep": _pct_positive("keep", {"likely"}),
+        "confidence": {"dist": conf_counts, "n": conf_n},
+    }
+
     # Build global stats
     global_stats = {
         "activeStudents": active_count,
@@ -840,6 +895,7 @@ def main():
         "institutions": sorted(confirmed_institutions),
         "cohorts": cohorts_list,
         "growth": growth,
+        "feedback": feedback,
         "students": students,
         "mentors": mentors,
     }

--- a/scripts/template.html
+++ b/scripts/template.html
@@ -15,6 +15,7 @@
 <meta name="twitter:description" content="Live dashboard tracking WordPress Credits program: students, mentors, institutions, contributions, and translation activity.">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.css"/>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.js"></script>
 <style>
 :root{--wp-blue:#0073aa;--wp-blue-dark:#005a87;--wp-green:#00a32a;--wp-orange:#dba617;--wp-red:#d63638;--bg:#f0f0f1;--card-bg:#fff;--text:#1d2327;--text-light:#646970;--border:#c3c4c7;--row-hover:#f6f7f7}
 *{box-sizing:border-box;margin:0;padding:0}
@@ -265,6 +266,15 @@ function tc(name){return TEAM_COLORS[name]||'#546e7a';}
       <div class="card"><div class="num">${g.sponsorCount}</div><div class="lbl">Sponsors</div></div>
       <div class="card"><div class="num">${g.totalCourses.toLocaleString()}</div><div class="lbl">Learn Courses Completed</div></div>
     </div>
+    <div class="chart-container">
+      <h3>Growth Over Time</h3>
+      <div style="display:flex;flex-wrap:wrap;gap:16px;margin-bottom:8px;font-size:12px;color:var(--text-light)">
+        <span style="display:flex;align-items:center;gap:5px"><span style="width:10px;height:10px;border-radius:2px;background:#1D9E75"></span>Joined</span>
+        <span style="display:flex;align-items:center;gap:5px"><span style="width:10px;height:10px;border-radius:2px;background:#378ADD"></span>Graduated</span>
+        <span style="display:flex;align-items:center;gap:5px"><span style="width:14px;height:3px;background:#D85A30;display:inline-block"></span>Cumulative joined</span>
+      </div>
+      <div style="position:relative;height:320px"><canvas id="growthChart"></canvas></div>
+    </div>
     <div class="charts-row">
       <div class="chart-container"><h3>Students by Contribution Team</h3><div class="bar-chart" id="teamChart"></div></div>
       <div class="chart-container"><h3>Students by Field of Study</h3><div id="fosChart"></div></div>
@@ -272,6 +282,22 @@ function tc(name){return TEAM_COLORS[name]||'#546e7a';}
 
     <div class="chart-container"><h3>Institutions Around the World</h3><div id="instMap"></div></div>
   `;
+  // Growth over time (joining vs graduating, by month)
+  (function(){
+    var gr = D.growth, cv = document.getElementById('growthChart');
+    if (!gr || !cv || !gr.months || !gr.months.length || typeof Chart === 'undefined') return;
+    new Chart(cv, {
+      data: { labels: gr.months, datasets: [
+        { type:'bar', label:'Joined', data:gr.joined, backgroundColor:'#1D9E75', yAxisID:'y' },
+        { type:'bar', label:'Graduated', data:gr.graduated, backgroundColor:'#378ADD', yAxisID:'y' },
+        { type:'line', label:'Cumulative joined', data:gr.cumulativeJoined, borderColor:'#D85A30', backgroundColor:'#D85A30', borderWidth:2, tension:0.3, pointRadius:2, yAxisID:'y1' }
+      ]},
+      options: { responsive:true, maintainAspectRatio:false, plugins:{ legend:{ display:false } },
+        scales:{ x:{ grid:{ display:false }, ticks:{ autoSkip:true, maxRotation:45, minRotation:45 } },
+          y:{ beginAtZero:true, title:{ display:true, text:'per month' } },
+          y1:{ position:'right', beginAtZero:true, grid:{ drawOnChartArea:false }, title:{ display:true, text:'cumulative' } } } }
+    });
+  })();
   // Team chart
   const teams = Object.entries(g.teamDistribution).sort((a,b) => b[1]-a[1]);
   const mx = teams[0]?teams[0][1]:1;

--- a/scripts/template.html
+++ b/scripts/template.html
@@ -97,12 +97,14 @@ tbody tr:last-child td{border-bottom:none}
   <div class="nav-item" data-section="contributions">Contributions</div>
   <div class="nav-item" data-section="learn">Learn</div>
   <div class="nav-item" data-section="mentors">Mentors</div>
+  <div class="nav-item" data-section="feedback">Feedback</div>
 </div>
 <div class="content">
   <div class="section active" id="sec-global"></div>
   <div class="section" id="sec-contributions"></div>
   <div class="section" id="sec-learn"></div>
   <div class="section" id="sec-mentors"></div>
+  <div class="section" id="sec-feedback"></div>
 </div>
 <div class="footer">Data sourced from Airtable &amp; WordPress.org profiles &bull; The dashboard refreshes once a week &mdash; every Monday at 6:00 UTC</div>
 <script>
@@ -519,6 +521,37 @@ function tc(name){return TEAM_COLORS[name]||'#546e7a';}
   }
   document.getElementById('mS').addEventListener('input',r);
   r();
+})();
+// Feedback section (aggregate, experience-only)
+(function(){
+  var fb = D.feedback, el = document.getElementById('sec-feedback');
+  if (!el) return;
+  if (!fb || !fb.responses) { el.innerHTML = '<div class="chart-container"><h3>Student Feedback</h3><p style="color:var(--text-light)">No feedback yet.</p></div>'; return; }
+  var pct = function(o){ return (o && o.pct!=null) ? o.pct+'%' : '—'; };
+  var rat = function(o){ return (o && o.avg!=null) ? o.avg.toFixed(1) : '—'; };
+  var barW = function(o){ return (o && o.avg!=null) ? Math.round(o.avg/5*100) : 0; };
+  var ratingCard = function(title,o){ return '<div class="chart-container"><h3>'+title+'</h3>'
+    + '<div style="font-size:22px;font-weight:800;color:var(--text);margin-bottom:8px">'+rat(o)+' <span style="font-size:13px;color:var(--text-light);font-weight:400">/ 5</span></div>'
+    + '<div style="height:6px;border-radius:3px;background:var(--border)"><div style="width:'+barW(o)+'%;height:6px;border-radius:3px;background:#EF9F27"></div></div></div>'; };
+  var c = fb.confidence.dist || {}, cn = fb.confidence.n || 1;
+  var confOrder = [['Very confident','#0F6E56'],['Confident','#5DCAA5'],['Neutral','#B4B2A9'],['Not very confident','#D85A30']];
+  var seg = confOrder.map(function(x){ var v=c[x[0]]||0; return v? '<div style="width:'+(v/cn*100)+'%;background:'+x[1]+'"></div>':''; }).join('');
+  var leg = confOrder.map(function(x){ var v=c[x[0]]||0; return '<span style="display:flex;align-items:center;gap:5px"><span style="width:10px;height:10px;border-radius:2px;background:'+x[1]+'"></span>'+x[0]+' '+Math.round(v/cn*100)+'%</span>'; }).join('');
+  el.innerHTML = ''
+    + '<div class="cards">'
+    +   '<div class="card"><div class="num">'+pct(fb.recommend)+'</div><div class="lbl">Would recommend WP Credits</div></div>'
+    +   '<div class="card"><div class="num">'+pct(fb.keep)+'</div><div class="lbl">Will keep contributing</div></div>'
+    + '</div>'
+    + '<div class="charts-row">'
+    +   ratingCard('Ease of getting started', fb.ratings.ease)
+    +   ratingCard('Project / website satisfaction', fb.ratings.satisfaction)
+    +   ratingCard('Perceived impact', fb.ratings.impact)
+    + '</div>'
+    + '<div class="chart-container"><h3>Confidence contributing</h3>'
+    +   '<p style="margin:0 0 8px;font-size:12px;color:var(--text-light)">Asked after picking the contribution team, before contributing begins.</p>'
+    +   '<div style="display:flex;height:22px;border-radius:6px;overflow:hidden">'+seg+'</div>'
+    +   '<div style="display:flex;flex-wrap:wrap;gap:14px;margin-top:8px;font-size:12px;color:var(--text-light)">'+leg+'</div></div>'
+    + '<p style="font-size:12px;color:var(--text-light);margin-top:12px">Aggregated from '+fb.responses+' anonymous responses — no individual data shown.</p>';
 })();
 </script>
 </body>

--- a/scripts/template.html
+++ b/scripts/template.html
@@ -262,9 +262,12 @@ function tc(name){return TEAM_COLORS[name]||'#546e7a';}
     <div class="cards">
       <div class="card"><div class="num" id="ovActive">${g.activeStudents}</div><div class="lbl">Active Students</div></div>
       <div class="card"><div class="num">${g.graduates}</div><div class="lbl">Graduates</div></div>
+      <div class="card"><div class="num">${g.dropouts!=null?g.dropouts:'—'}</div><div class="lbl">Dropped Out</div></div>
       <div class="card"><div class="num">${g.totalHours.toLocaleString()}</div><div class="lbl">Contribution Hours</div></div>
       <div class="card"><div class="num">${g.partnerInstitutions}</div><div class="lbl">Institutions</div></div>
+      <div class="card"><div class="num">${Object.keys(g.instCountries||{}).length}</div><div class="lbl">Countries</div></div>
       <div class="card"><div class="num">${g.activeMentors}</div><div class="lbl">Active Mentors</div></div>
+      <div class="card"><div class="num">${g.vettedMentors!=null?g.vettedMentors:'—'}</div><div class="lbl">Vetted Mentors</div></div>
       <div class="card"><div class="num">${g.sponsorCount}</div><div class="lbl">Sponsors</div></div>
       <div class="card"><div class="num">${g.totalCourses.toLocaleString()}</div><div class="lbl">Learn Courses Completed</div></div>
     </div>


### PR DESCRIPTION
## Summary

Step 3 of the dashboard rebuild — new visualizations on top of the step-1 data-quality work ([#106](https://github.com/WordPress/WPCredits-Tracker/pull/106)). Three additions, all previewed with real data before building. **No UI redesign** here (that's the next step); these slot into the existing layout.

Validated with unit + full integration tests over real-data-shaped mocks (the real build runs in CI with the `AIRTABLE_PAT` secret). Adds Chart.js via CDN.

### 1. Growth over time (Overview)
Monthly **joining vs. graduating** combo chart + cumulative-joined line.
- Intake bucketed by "Start Date" month, year inferred from record creation (Start Date has no year).
- Graduations by **Form 3 submission date**, falling back to internship end date (and ready to prefer a future `Graduated on` field).
- Future months excluded; gaps zero-filled.

### 2. Student feedback (new "Feedback" tab)
Aggregate, **experience-only**, sourced from the Feedback table (the student-linked layer; the Students-Reports→submissions link was too sparse — 59/605 — to use).
- Would-recommend % · keep-contributing % · ease / satisfaction / impact rating averages · confidence distribution.
- No individual data, no mentor ratings. Messy select options (`" Likely"` vs `"Likely"`, junk choices) normalized/ignored via `status_key()`.

### 3. Surfaced previously-captured metrics (Overview)
Cards for data step 1 computed but didn't display: **Dropped Out**, **Vetted Mentors** (pipeline), **Countries** (distinct countries with confirmed institutions). Cohort filter dropdowns also populate now (from `D.cohorts`).

## Deferred
**Post-graduation activity** was intentionally left out: the big graduation wave was April–May 2026, so it's too early to measure meaningful post-grad activity (would read ~0%), and profile-date scraping is fragile. Best built later as weekly contribution snapshots.

## Notes
- Confidence is labeled as asked before contributing (program-owner's framing); underlying data groups it with mid-program satisfaction — easy caption change if needed.
- The form redesign (a repeated "growth spine" for true before/after curves) is a separate, future change on the Airtable side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Part of #108.