### PR TITLE
Restructure public Overview into a Scale / Contribution / Outcomes story

### DIFF
--- a/scripts/build_dashboard.py
+++ b/scripts/build_dashboard.py
@@ -892,9 +892,15 @@ def main():
         key=cohort_sort_key,
     )
 
+    # Friendly "Data as of" date for the dashboard trust footer (portable, no
+    # platform-specific strftime padding flags).
+    today = date.today()
+    last_updated = today.strftime("%B ") + str(today.day) + today.strftime(", %Y")
+
     # Build final data blob
     data_blob = {
         "global": global_stats,
+        "lastUpdated": last_updated,
         "translationTotals": translation_totals,
         "institutions": sorted(confirmed_institutions),
         "cohorts": cohorts_list,

--- a/scripts/template.html
+++ b/scripts/template.html
@@ -37,6 +37,10 @@ body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubunt
 .chart-container h3{font-size:15px;font-weight:600;margin-bottom:16px;color:var(--text)}
 .charts-row{display:grid;grid-template-columns:1fr 1fr;gap:24px;margin-bottom:24px}
 @media(max-width:900px){.charts-row{grid-template-columns:1fr}}
+.act-label{font-size:12px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--text-light);margin:32px 0 14px}
+.act-label:first-child{margin-top:0}
+.card .act-sub{font-size:11px;color:var(--text-light);margin-top:6px}
+.trust-footer{font-size:12px;color:var(--text-light);border-top:1px solid var(--border);margin-top:4px;padding-top:16px}
 .bar-chart{display:flex;flex-direction:column;gap:10px}
 .bar-row{display:flex;align-items:center;gap:12px}
 .bar-label{width:130px;text-align:right;font-size:13px;font-weight:500;color:var(--text);flex-shrink:0}
@@ -258,18 +262,28 @@ function tc(name){return TEAM_COLORS[name]||'#546e7a';}
 (function(){
   const g = D.global;
   const el = document.getElementById('sec-global');
+  // Derived figures for the restructured, story-first Overview.
+  const transTotal = (D.translationTotals && D.translationTotals.total) || 0;
+  const teamCount = Object.keys(g.teamDistribution || {}).length;
+  const countryCount = Object.keys(g.instCountries || {}).length;
+  // Graduation rate — show both: completion among those who reached an outcome,
+  // with a context line for how many are still in-program. "Not moving forward"
+  // (never enrolled) is excluded from every denominator.
+  const grad = g.graduates || 0, drop = g.dropouts || 0, act = g.activeStudents || 0;
+  const finished = grad + drop, started = grad + drop + act;
+  const completionRate = finished > 0 ? Math.round(grad / finished * 100) : null;
+  const stillActivePct = started > 0 ? Math.round(act / started * 100) : 0;
+  // Experience signals from the feedback aggregate (may be absent on a fresh build).
+  const fb = D.feedback || {};
+  const recPct = (fb.recommend && fb.recommend.pct != null) ? fb.recommend.pct + '%' : '—';
+  const keepPct = (fb.keep && fb.keep.pct != null) ? fb.keep.pct + '%' : '—';
+  const updated = D.lastUpdated || '';
   el.innerHTML = `
+    <div class="act-label">Scale &amp; momentum</div>
     <div class="cards">
       <div class="card"><div class="num" id="ovActive">${g.activeStudents}</div><div class="lbl">Active Students</div></div>
-      <div class="card"><div class="num">${g.graduates}</div><div class="lbl">Graduates</div></div>
-      <div class="card"><div class="num">${g.dropouts!=null?g.dropouts:'—'}</div><div class="lbl">Dropped Out</div></div>
-      <div class="card"><div class="num">${g.totalHours.toLocaleString()}</div><div class="lbl">Contribution Hours</div></div>
-      <div class="card"><div class="num">${g.partnerInstitutions}</div><div class="lbl">Institutions</div></div>
-      <div class="card"><div class="num">${Object.keys(g.instCountries||{}).length}</div><div class="lbl">Countries</div></div>
-      <div class="card"><div class="num">${g.activeMentors}</div><div class="lbl">Active Mentors</div></div>
-      <div class="card"><div class="num">${g.vettedMentors!=null?g.vettedMentors:'—'}</div><div class="lbl">Vetted Mentors</div></div>
-      <div class="card"><div class="num">${g.sponsorCount}</div><div class="lbl">Sponsors</div></div>
-      <div class="card"><div class="num">${g.totalCourses.toLocaleString()}</div><div class="lbl">Learn Courses Completed</div></div>
+      <div class="card"><div class="num">${grad}</div><div class="lbl">Graduates</div></div>
+      <div class="card"><div class="num">${countryCount}</div><div class="lbl">Countries</div></div>
     </div>
     <div class="chart-container">
       <h3>Growth Over Time</h3>
@@ -280,12 +294,25 @@ function tc(name){return TEAM_COLORS[name]||'#546e7a';}
       </div>
       <div style="position:relative;height:320px"><canvas id="growthChart"></canvas></div>
     </div>
-    <div class="charts-row">
-      <div class="chart-container"><h3>Students by Contribution Team</h3><div class="bar-chart" id="teamChart"></div></div>
-      <div class="chart-container"><h3>Students by Field of Study</h3><div id="fosChart"></div></div>
-    </div>
-
     <div class="chart-container"><h3>WordPress Credits Partners</h3><div id="instMap"></div></div>
+
+    <div class="act-label">Real contribution</div>
+    <div class="cards">
+      <div class="card"><div class="num">${g.totalHours.toLocaleString()}</div><div class="lbl">Contribution Hours</div></div>
+      <div class="card"><div class="num">${transTotal.toLocaleString()}</div><div class="lbl">Translation Strings</div></div>
+      <div class="card"><div class="num">${teamCount}</div><div class="lbl">Contribution Teams</div></div>
+    </div>
+    <div class="chart-container"><h3>Students by Contribution Team</h3><div class="bar-chart" id="teamChart"></div></div>
+
+    <div class="act-label">Outcomes &amp; quality</div>
+    <div class="cards">
+      <div class="card"><div class="num">${completionRate != null ? completionRate + '%' : '—'}</div><div class="lbl">Graduation Rate</div>${started > 0 ? `<div class="act-sub">${stillActivePct}% still active</div>` : ''}</div>
+      <div class="card"><div class="num">${recPct}</div><div class="lbl">Would Recommend</div></div>
+      <div class="card"><div class="num">${keepPct}</div><div class="lbl">Keep Contributing</div></div>
+    </div>
+    <div class="chart-container"><h3>Students by Field of Study</h3><div id="fosChart"></div></div>
+
+    <div class="trust-footer">Data as of ${updated} &middot; sourced from Airtable and WordPress.org &middot; updated weekly</div>
   `;
   // Growth over time (joining vs graduating, by month)
   (function(){


### PR DESCRIPTION
First PR of the **public dashboard** rebuild (#108). Reframes the Overview from a flat 9-card grid into a three-act narrative aimed at institutions/partners/community — scale, then real contribution, then outcomes.

## Changes
- **Overview = three acts** (`scripts/template.html`):
  - **Scale & momentum** — Active students · Graduates · Countries, then the Growth-over-time chart and the partners map.
  - **Real contribution** — Contribution hours · Translation strings · Contribution teams, then the team-distribution chart (shows breadth beyond translation).
  - **Outcomes & quality** — Graduation rate · Would-recommend % · Keep-contributing %, then the field-of-study donut.
- **Graduation rate shows both**: a headline completion rate `graduates / (graduates + dropouts)` with a `% still active` context line. "Not moving forward" (never enrolled) is excluded from every denominator.
- **Dropped from the public Overview**: Dropped-Out count, Active/Vetted Mentors, Sponsors, Learn courses (internal/ops or training metrics).
- **Trust footer** — "Data as of <date> · sourced from Airtable and WordPress.org · updated weekly"; the build now emits `lastUpdated` (`scripts/build_dashboard.py`).

## Scope notes
- No `index.html` in this PR — it regenerates from the template via the `update-dashboard` Action after merge (same flow as #106/#107). **Trigger the Action post-merge** to publish.
- Removing the Learn/Mentors tabs and the per-student tables (→ the private dashboard, #109) is a **follow-up PR**, not this one.

## Validation
Rendered the new template against the **real data blob** baked into the current `index.html` (no Airtable PAT needed). With live numbers (277 active, 186 graduates, 30 dropouts): all three acts render, graduation rate shows **86% (56% still active)**, the growth chart, team bars, field-of-study donut, and Leaflet map all initialize, and there are **no console errors**.

Part of #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)