### PR TITLE
Fix build crash: drop deleted Airtable field affiliated_company

### DIFF
--- a/scripts/build_dashboard.py
+++ b/scripts/build_dashboard.py
@@ -73,7 +73,6 @@ FIELDS = {
         "student_reports": "fldnbYOM2vHPwJjpg",
         "sponsored": "fldFypFl2gQkUszXn",
         "sponsor_company": "fldtdhRzXWpfcb13w",
-        "affiliated_company": "flde2iNU183R2CYXa",
     },
     "institutions": {
         "name": "fldZQBu7XS2Z29jx4",


### PR DESCRIPTION
The **Update Dashboard Data** Action failed today (run [28233570728](https://github.com/WordPress/WPCredits-Tracker/actions/runs/28233570728)) with a 422 from Airtable while fetching the Mentors table.

## Cause
The mentors field map requested `affiliated_company` (`flde2iNU183R2CYXa`). That field was **deleted from Airtable** during field hygiene, so the API returns `422 Unprocessable Entity` and the build aborts before writing `index.html`. Unrelated to the Overview restructure (#115) — the build fails at the data-fetch stage, before touching the template.

## Fix
Remove the `affiliated_company` mapping. It was **dead code**: declared but never read since #106 switched sponsor counting to the Sponsors table.

## Validation
Cross-checked all **52** remaining field IDs the build references against the live base schema — every one still exists, so there's no other deleted-field 422 lurking. `build_dashboard.py` compiles.

Part of #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)