### PR TITLE
Rename Overview visuals to match the narrative + add subtitles

### DIFF
--- a/scripts/template.html
+++ b/scripts/template.html
@@ -35,6 +35,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubunt
 .card .lbl{font-size:11px;color:var(--text-light);margin-top:4px;text-transform:uppercase;letter-spacing:.5px}
 .chart-container{background:var(--card-bg);border:1px solid var(--border);border-radius:10px;padding:24px;margin-bottom:24px}
 .chart-container h3{font-size:15px;font-weight:600;margin-bottom:16px;color:var(--text)}
+.chart-sub{font-size:12px;color:var(--text-light);margin:-10px 0 16px;line-height:1.4}
 .charts-row{display:grid;grid-template-columns:1fr 1fr;gap:24px;margin-bottom:24px}
 @media(max-width:900px){.charts-row{grid-template-columns:1fr}}
 .act-label{font-size:12px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--text-light);margin:32px 0 14px}
@@ -286,7 +287,8 @@ function tc(name){return TEAM_COLORS[name]||'#546e7a';}
       <div class="card"><div class="num">${countryCount}</div><div class="lbl">Countries</div></div>
     </div>
     <div class="chart-container">
-      <h3>Growth Over Time</h3>
+      <h3>How the program is growing</h3>
+      <div class="chart-sub">Students joining and graduating, month by month</div>
       <div style="display:flex;flex-wrap:wrap;gap:16px;margin-bottom:8px;font-size:12px;color:var(--text-light)">
         <span style="display:flex;align-items:center;gap:5px"><span style="width:10px;height:10px;border-radius:2px;background:#1D9E75"></span>Joined</span>
         <span style="display:flex;align-items:center;gap:5px"><span style="width:10px;height:10px;border-radius:2px;background:#378ADD"></span>Graduated</span>
@@ -294,7 +296,7 @@ function tc(name){return TEAM_COLORS[name]||'#546e7a';}
       </div>
       <div style="position:relative;height:320px"><canvas id="growthChart"></canvas></div>
     </div>
-    <div class="chart-container"><h3>WordPress Credits Partners</h3><div id="instMap"></div></div>
+    <div class="chart-container"><h3>Where our partners are</h3><div class="chart-sub">Partner institutions around the world</div><div id="instMap"></div></div>
 
     <div class="act-label">Real contribution</div>
     <div class="cards">
@@ -302,7 +304,7 @@ function tc(name){return TEAM_COLORS[name]||'#546e7a';}
       <div class="card"><div class="num">${transTotal.toLocaleString()}</div><div class="lbl">Translation Strings</div></div>
       <div class="card"><div class="num">${teamCount}</div><div class="lbl">Contribution Teams</div></div>
     </div>
-    <div class="chart-container"><h3>Students by Contribution Team</h3><div class="bar-chart" id="teamChart"></div></div>
+    <div class="chart-container"><h3>What students are contributing to</h3><div class="chart-sub">How many students work on each WordPress team</div><div class="bar-chart" id="teamChart"></div></div>
 
     <div class="act-label">Outcomes &amp; quality</div>
     <div class="cards">
@@ -310,7 +312,7 @@ function tc(name){return TEAM_COLORS[name]||'#546e7a';}
       <div class="card"><div class="num">${recPct}</div><div class="lbl">Would Recommend</div></div>
       <div class="card"><div class="num">${keepPct}</div><div class="lbl">Keep Contributing</div></div>
     </div>
-    <div class="chart-container"><h3>Students by Field of Study</h3><div id="fosChart"></div></div>
+    <div class="chart-container"><h3>Who's joining us</h3><div class="chart-sub">The academic backgrounds students bring</div><div id="fosChart"></div></div>
 
     <div class="trust-footer">Data as of ${updated} &middot; sourced from Airtable and WordPress.org &middot; updated weekly</div>
   `;


### PR DESCRIPTION
Swaps the database-style chart titles on the public Overview for narrative ones that answer the question a visitor is actually asking, each with a one-line subtitle explaining the visual.

| Visual | Was | Now | Subtitle |
|---|---|---|---|
| Growth chart | Growth Over Time | **How the program is growing** | Students joining and graduating, month by month |
| Partners map | WordPress Credits Partners | **Where our partners are** | Partner institutions around the world |
| Contribution-team bars | Students by Contribution Team | **What students are contributing to** | How many students work on each WordPress team |
| Field-of-study donut | Students by Field of Study | **Who's joining us** | The academic backgrounds students bring |

Scope: Overview visuals only — the Learn/Mentors/Feedback tabs are untouched since they're being reworked in the upcoming nav-trim / Voices PRs. Adds a small `.chart-sub` style; no logic changes.

## Validation
Rendered the new template against live data: all four title/subtitle pairs render with correct spacing, the charts and map still initialize, and there are no console errors.

Part of #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)