### PR TITLE
Remove redundant "Data as of" trust footer from Overview

### DIFF
--- a/scripts/build_dashboard.py
+++ b/scripts/build_dashboard.py
@@ -903,15 +903,9 @@ def main():
         key=cohort_sort_key,
     )
 
-    # Friendly "Data as of" date for the dashboard trust footer (portable, no
-    # platform-specific strftime padding flags).
-    today = date.today()
-    last_updated = today.strftime("%B ") + str(today.day) + today.strftime(", %Y")
-
     # Build final data blob
     data_blob = {
         "global": global_stats,
-        "lastUpdated": last_updated,
         "translationTotals": translation_totals,
         "institutions": sorted(confirmed_institutions),
         "cohorts": cohorts_list,

--- a/scripts/template.html
+++ b/scripts/template.html
@@ -41,7 +41,6 @@ body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubunt
 .act-label{font-size:12px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--text-light);margin:32px 0 14px}
 .act-label:first-child{margin-top:0}
 .card .act-sub{font-size:11px;color:var(--text-light);margin-top:6px}
-.trust-footer{font-size:12px;color:var(--text-light);border-top:1px solid var(--border);margin-top:4px;padding-top:16px}
 .bar-chart{display:flex;flex-direction:column;gap:10px}
 .bar-row{display:flex;align-items:center;gap:12px}
 .bar-label{width:130px;text-align:right;font-size:13px;font-weight:500;color:var(--text);flex-shrink:0}
@@ -300,7 +299,6 @@ function tc(name){return TEAM_COLORS[name]||'#546e7a';}
   const fb = D.feedback || {};
   const recPct = (fb.recommend && fb.recommend.pct != null) ? fb.recommend.pct + '%' : '—';
   const keepPct = (fb.keep && fb.keep.pct != null) ? fb.keep.pct + '%' : '—';
-  const updated = D.lastUpdated || '';
   el.innerHTML = `
     <div class="act-label">Scale &amp; momentum</div>
     <div class="cards">
@@ -335,8 +333,6 @@ function tc(name){return TEAM_COLORS[name]||'#546e7a';}
       <div class="card"><div class="num">${keepPct}</div><div class="lbl">Keep Contributing</div></div>
     </div>
     <div class="chart-container"><h3>Who's joining us</h3><div class="chart-sub">The academic backgrounds students bring</div><div id="fosChart"></div></div>
-
-    <div class="trust-footer">Data as of ${updated} &middot; sourced from Airtable and WordPress.org &middot; updated weekly</div>
   `;
   // Growth over time (joining vs graduating, by month)
   (function(){


### PR DESCRIPTION
The Overview showed a *"Data as of June 26, 2026 · sourced from Airtable and WordPress.org · updated weekly"* line (added in #115) that duplicates the existing site-wide footer: *"Data sourced from Airtable & WordPress.org profiles • The dashboard refreshes once a week — every Monday at 6:00 UTC."*

Removes the duplicate cleanly:
- the `.trust-footer` markup in the Overview
- its CSS rule
- the now-unused `lastUpdated` field the build emitted for it

The original site-wide footer is unchanged. Verified the generated HTML no longer contains "Data as of" and still has the kept footer; build compiles.

Part of #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)