### PR TITLE
Add Voices section: curated student quotes (renames Feedback tab)

### DIFF
--- a/scripts/template.html
+++ b/scripts/template.html
@@ -94,6 +94,12 @@ tbody tr:last-child td{border-bottom:none}
 .sponsors-row a{display:inline-flex;align-items:center}
 .sponsors-row img{max-height:34px;max-width:140px;width:auto;object-fit:contain;opacity:.6;filter:grayscale(100%);transition:opacity .15s ease,filter .15s ease}
 .sponsors-row a:hover img{opacity:1;filter:none}
+.voices-grid{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:8px}
+@media(max-width:760px){.voices-grid{grid-template-columns:1fr}}
+.voice{background:var(--card-bg);border:1px solid var(--border);border-radius:10px;padding:20px 22px}
+.voice-q{font-size:15px;line-height:1.6;color:var(--text)}
+.voice-meta{margin-top:14px;display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-size:12px;color:var(--text-light)}
+.voice-tag{border:1px solid var(--border);border-radius:4px;padding:1px 6px;font-size:11px}
 @media(max-width:768px){.nav{overflow-x:auto}.nav-item{padding:10px 14px;font-size:13px}.content{padding:16px}.bar-label{width:80px;font-size:11px}}
 </style>
 </head>
@@ -107,7 +113,7 @@ tbody tr:last-child td{border-bottom:none}
   <div class="nav-item" data-section="contributions">Contributions</div>
   <div class="nav-item" data-section="learn">Learn</div>
   <div class="nav-item" data-section="mentors">Mentors</div>
-  <div class="nav-item" data-section="feedback">Feedback</div>
+  <div class="nav-item" data-section="feedback">Voices</div>
 </div>
 <div class="content">
   <div class="section active" id="sec-global"></div>
@@ -587,7 +593,20 @@ function tc(name){return TEAM_COLORS[name]||'#546e7a';}
   var confOrder = [['Very confident','#0F6E56'],['Confident','#5DCAA5'],['Neutral','#B4B2A9'],['Not very confident','#D85A30']];
   var seg = confOrder.map(function(x){ var v=c[x[0]]||0; return v? '<div style="width:'+(v/cn*100)+'%;background:'+x[1]+'"></div>':''; }).join('');
   var leg = confOrder.map(function(x){ var v=c[x[0]]||0; return '<span style="display:flex;align-items:center;gap:5px"><span style="width:10px;height:10px;border-radius:2px;background:'+x[1]+'"></span>'+x[0]+' '+Math.round(v/cn*100)+'%</span>'; }).join('');
+  var voices = [
+    {q:"My time in the WordPress Credits Internship program was enlightening. This was my first time actively contributing to a real open-source project, and my first internship. I learned a lot about my own skills, about open-source software, and about the WordPress Foundation and WordPress software. Additionally, I would like to think that my contribution will have a lasting impact on the local WordPress community.", who:"Carolyn · Central New Mexico Community College", lang:"EN"},
+    {q:"This program was a great learning experience for me. I learned how to build and customize websites using WordPress, and also gained basic knowledge of HTML, CSS, and PHP. The mentors were very supportive and guided us throughout the journey. This course helped me gain confidence and real-world experience. I would highly recommend it to anyone interested in starting a career in WordPress and web development.", who:"Saad · Ahmad's Education", lang:"EN"},
+    {q:"WordPress Credits was a great experience for me. I could see how a global project works and I helped translate over 1,200 phrases. Sometimes you need patience, but the results give a lot of satisfaction. If you want to learn new technical skills and build your own portfolio, you should definitely join this program.", who:"Wiktoria · Krakow University of Economics", lang:"EN"},
+    {q:"El curso ha estado genial y la experiencia ha sido muy positiva. Me ha gustado mucho integrarme en la comunidad de WordPress y ver cómo se trabaja en un proyecto real de código abierto. Ha estado muy bien organizado y me ha servido para aprender un montón sobre la localización y traducción de software. Muy recomendable.", who:"Juan Manuel · IES Azarquiel", lang:"ES"},
+    {q:"Podría decir que no tengan miedo y se metan con todo menos con miedo a este programa, porque es una experiencia muy bonita, aprendes muchísimas cosas, sales de tu rutina diaria, te hace crecer personalmente y profesionalmente.", who:"Rossana · Universidad Privada Franz Tamayo", lang:"ES"},
+    {q:"Mi experiencia en WPCredits fue muy positiva ya que aprendí sobre WordPress, la colaboración en comunidades de código abierto y la importancia de compartir conocimientos. Aunque al inicio fue un reto familiarizarme con las diferentes plataformas, con el tiempo logré adaptarme y desarrollar nuevas habilidades. Recomiendo esta experiencia a otros estudiantes porque permite aprender herramientas útiles y participar en una comunidad tecnológica.", who:"Teresa · Universidad Fidélitas", lang:"ES"}
+  ];
+  var voicesHtml = voices.map(function(v){ return '<div class="voice"><div class="voice-q">“'+v.q+'”</div><div class="voice-meta"><span>'+v.who+'</span><span class="voice-tag">'+v.lang+'</span></div></div>'; }).join('');
   el.innerHTML = ''
+    + '<h3 style="font-size:18px;margin:4px 0 6px">Voices from the program</h3>'
+    + '<p style="font-size:13px;color:var(--text-light);margin:0 0 18px">In students’ own words, shared with their consent.</p>'
+    + '<div class="voices-grid">' + voicesHtml + '</div>'
+    + '<h3 style="font-size:18px;margin:32px 0 14px">How students rate the experience</h3>'
     + '<div class="cards">'
     +   '<div class="card"><div class="num">'+pct(fb.recommend)+'</div><div class="lbl">Would recommend WP Credits</div></div>'
     +   '<div class="card"><div class="num">'+pct(fb.keep)+'</div><div class="lbl">Will keep contributing</div></div>'
@@ -601,7 +620,7 @@ function tc(name){return TEAM_COLORS[name]||'#546e7a';}
     +   '<p style="margin:0 0 8px;font-size:12px;color:var(--text-light)">Asked after picking the contribution team, before contributing begins.</p>'
     +   '<div style="display:flex;height:22px;border-radius:6px;overflow:hidden">'+seg+'</div>'
     +   '<div style="display:flex;flex-wrap:wrap;gap:14px;margin-top:8px;font-size:12px;color:var(--text-light)">'+leg+'</div></div>'
-    + '<p style="font-size:12px;color:var(--text-light);margin-top:12px">Aggregated from '+fb.responses+' anonymous responses — no individual data shown.</p>';
+    + '<p style="font-size:12px;color:var(--text-light);margin-top:12px">The metrics above are aggregated from '+fb.responses+' anonymous responses — no individual data shown.</p>';
 })();
 </script>
 </body>


### PR DESCRIPTION
PR 2 of the public-dashboard plan. Renames the **Feedback** tab to **Voices** and leads it with six curated student quotes from the Feedback table's `Review` field (consented public reviews), above the existing aggregate experience metrics.

## Details
- **6 quotes**, balanced **3 EN / 3 ES**, one per institution across the **US, Bangladesh, Poland, Spain, Bolivia, and Costa Rica**: Carolyn, Saad, Wiktoria, Juan Manuel, Rossana, Teresa.
- Attributed by **first name · institution**, each with a small **language tag** (per the agreed format).
- **Original language** shown (no translation), verbatim — with two minor display fixes: Wiktoria's "1 200" → "1,200", and a "prendí" → "aprendí" typo in Teresa's (plus a closing period).
- Quotes are a **static curated list in the template** (no Airtable dependency), same pattern as the sponsor strip — so I picked; easy to swap.
- The "aggregated from N anonymous responses — no individual data" note is scoped to the metrics (the quotes are named, consented reviews).

## Selection
Drawn from 121 non-empty reviews → 66 well-sized → a diverse pool. 13 more strong candidates are available (incl. Università di Pisa, ERAP/India, Riga, an Italian quote) if you want to swap any.

## Validation
Rendered against live data: the tab shows **Voices** in the nav, all 6 cards with correct attribution + language tags, curly-quoted verbatim text, responsive (2-up on desktop, 1-up on mobile), no console errors. Template-only change; no build changes.

Part of #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)