### PR TITLE
Harden build: survive deleted/renamed Airtable fields

### DIFF
--- a/scripts/build_dashboard.py
+++ b/scripts/build_dashboard.py
@@ -153,7 +153,14 @@ def get_airtable_pat():
 
 
 def fetch_all_records(base_id, table_id, field_ids, pat):
-    """Fetch all records from Airtable table with pagination."""
+    """Fetch all records from an Airtable table (paginated).
+
+    Requests only the fields the build needs. If Airtable rejects that with a
+    422 — which is what happens when a requested field ID was deleted or renamed
+    in the base — drop the field filter, log a warning, and refetch all fields
+    so a single removed field degrades gracefully (it just reads as None via
+    get_field_value) instead of failing the whole build.
+    """
     url = f"{API_URL}/{base_id}/{table_id}"
     headers = {"Authorization": f"Bearer {pat}"}
     params = {"fields[]": field_ids, "returnFieldsByFieldId": "true", "pageSize": 100}
@@ -167,6 +174,23 @@ def fetch_all_records(base_id, table_id, field_ids, pat):
 
         try:
             r = requests.get(url, headers=headers, params=params, timeout=10)
+        except requests.RequestException as e:
+            print(f"Error fetching {table_id}: {e}", file=sys.stderr)
+            raise
+
+        if r.status_code == 422 and "fields[]" in params:
+            print(
+                f"Warning: {table_id} rejected the requested field list (422) — a "
+                f"mapped field was likely deleted or renamed in Airtable. Refetching "
+                f"all fields so the build continues; tidy up FIELDS when convenient.",
+                file=sys.stderr,
+            )
+            params.pop("fields[]")
+            all_records = []
+            offset = None
+            continue
+
+        try:
             r.raise_for_status()
         except requests.RequestException as e:
             print(f"Error fetching {table_id}: {e}", file=sys.stderr)


### PR DESCRIPTION
The build requests specific field IDs (`fields[]=…`), so if any one is deleted or renamed in Airtable, the whole table fetch returns **422** and the build fails. This has broken the scheduled build **twice** — #116 (`affiliated_company`) and #127 (`Start Date`).

## Change
On a 422 from the field-filtered request, `fetch_all_records` now:
1. logs a warning naming the table,
2. drops the `fields[]` filter, and
3. refetches that table with **all** fields.

A removed field then simply reads as `None` (via `get_field_value`) and the build completes, instead of failing the whole run. The **normal path is unchanged** (still requests only the needed fields, small payloads); the all-fields refetch only kicks in when a mapping has gone stale — and the warning flags it so we can tidy `FIELDS` at leisure.

## Validation
Unit-tested with a mocked Airtable: a 422 on the field-filtered request triggers the warning, refetches without `fields[]`, and returns the records. Compiles.

Part of #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)