### PR TITLE
Slim public data blob to aggregates + anonymous student rows (privacy)

### DIFF
--- a/scripts/build_dashboard.py
+++ b/scripts/build_dashboard.py
@@ -905,16 +905,26 @@ def main():
         key=cohort_sort_key,
     )
 
-    # Build final data blob
+    # Public data blob — aggregates plus ANONYMOUS per-student rows only. Names,
+    # WordPress usernames, institutions, and the entire mentors list are not
+    # emitted: the public dashboard doesn't render per-person detail (that lives
+    # in the private dashboard). Keep only the student fields the template uses.
+    public_students = [
+        {
+            "status": s["status"],
+            "is_graduate": s["is_graduate"],
+            "fieldOfStudy": s["fieldOfStudy"],
+            "total_strings": s.get("total_strings", 0),
+        }
+        for s in students
+    ]
+
     data_blob = {
         "global": global_stats,
         "translationTotals": translation_totals,
-        "institutions": sorted(confirmed_institutions),
-        "cohorts": cohorts_list,
         "growth": growth,
         "feedback": feedback,
-        "students": students,
-        "mentors": mentors,
+        "students": public_students,
     }
 
     print(f"Built dashboard with {len(students)} students and {len(mentors)} mentors", file=sys.stderr)


### PR DESCRIPTION
Follow-up to #131. The nav trim removed the per-person **views**, but the baked-in JSON blob still carried student and mentor **names + WordPress usernames** (visible via *View Source*). This removes that exposure.

## Change
The emitted `data_blob` now contains only what the public template actually uses:
- **`students`**: anonymous rows of `{status, is_graduate, fieldOfStudy, total_strings}` — no names, usernames, institutions, teams, or cohorts.
- **`mentors`**: dropped entirely (unused after the nav trim).
- **`institutions` / `cohorts`**: dropped (unused after the table filters were removed).

Internal processing is unchanged — the build still fetches full records for WP.org scraping and cross-referencing; only the **public output** is slimmed.

## Validation
Rendered the slimmed blob through the template against live data:
- Overview **field-of-study donut** renders (492 students, correct breakdown).
- **Contributions** totals render (101,818 strings · 129 translating students) + donut.
- No console errors.
- Blob PII check: `wp_username`, `wp_profile`, `institution`, `teams`, `country_normalized`, and the mentor student-lists are all **absent**.

Part of #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)