### PR TITLE
Rebuild Contributions tab: impact metrics instead of translation table

### DIFF
--- a/scripts/build_dashboard.py
+++ b/scripts/build_dashboard.py
@@ -43,6 +43,9 @@ FIELDS = {
         "teams": "fldwPGiajTLTu1Vqi",
         "internship_end_date": "fldLwLXupWurmimc7",
         "internship_start_date": "fldeadC0FAkXAxa17",
+        "first_contribution": "fld9AmBSoV87iaeMU",  # "Post Reflection: Your First Contribution"
+        "event_url": "fldJODnqx8jxGn0ra",            # WP event participation URL
+        "website_url": "fld2n1L2vcwDtlPlg",          # Personal Website URL (site built)
         "lessons": "fldE1rkXbTWJe8bBq",
         "mentor": "fldSBTwMgno8ecQ2X",
         # Learn course grade fields (non-empty = completed)
@@ -106,6 +109,7 @@ FIELDS = {
     },
     # Student feedback (student-linked layer). Aggregate, experience-only.
     "feedback": {
+        "email": "fldJcJQSgPIJ7XamR",          # used only to scope "keep" to graduates
         "ease": "fldn7M6U4xXurEgJ2",          # rating 1-5
         "satisfaction": "fldJPTEix369b8NOw",   # rating 1-5
         "impact": "fldxtEUsunNgjyKXV",         # rating 1-5
@@ -501,6 +505,12 @@ def main():
     total_hours = 0
     field_of_study_stats = {}
     country_from_mentor = {}  # Track which students have which country via mentor
+    # Contributions-tab metrics
+    first_contributions = 0
+    event_participants = 0
+    sites_created = 0
+    inst_quarters = {}   # institution name -> set of (year, quarter) students started in
+    grad_emails = set()  # emails of graduates, to scope "keep contributing" feedback
 
     for rec in students_reports_records:
         name = get_field_value(rec, FIELDS["students_reports"]["name"])
@@ -540,6 +550,23 @@ def main():
         elif status_n == NOT_MOVING_FORWARD_KEY:
             not_moving_forward_count += 1
 
+        # Contributions-tab metrics, counted across all reports (an artifact like a
+        # first contribution / site / event stands even if the student later left).
+        if get_field_value(rec, FIELDS["students_reports"]["first_contribution"]):
+            first_contributions += 1
+        if get_field_value(rec, FIELDS["students_reports"]["event_url"]):
+            event_participants += 1
+        if get_field_value(rec, FIELDS["students_reports"]["website_url"]):
+            sites_created += 1
+        # Repeat cohorts: the distinct year-quarters each school enrolled students in.
+        fc_email = get_field_value(rec, FIELDS["students_reports"]["email"])
+        fc_srec = students_by_email.get(fc_email.strip().lower()) if fc_email else None
+        fc_inst = get_field_value(rec, FIELDS["students_reports"]["institution"]) or []
+        if fc_srec and fc_inst and fc_inst[0] in institutions_lookup:
+            fc_sd = parse_iso_date(get_field_value(fc_srec, FIELDS["students"]["start_date"]))
+            if fc_sd:
+                inst_quarters.setdefault(institutions_lookup[fc_inst[0]]["name"], set()).add((fc_sd.year, (fc_sd.month - 1) // 3))
+
         # Skip students with non-active statuses (Not moving forward, SPAM, Dropped out, Paused, etc.)
         if status_n not in INCLUDED_STATUS_KEYS:
             continue
@@ -574,6 +601,8 @@ def main():
         email_key = report_email.strip().lower() if report_email else ""
         name_normalized = " ".join(name.strip().lower().split()) if name else ""
         student_rec = students_by_email.get(email_key) or students_by_name.get(name_normalized)
+        if is_graduate and email_key:
+            grad_emails.add(email_key)
         if student_rec:
             fos_obj = get_field_value(student_rec, FIELDS["students"]["field_of_study"])
             if fos_obj and isinstance(fos_obj, dict):
@@ -878,6 +907,27 @@ def main():
         "confidence": {"dist": conf_counts, "n": conf_n},
     }
 
+    # Contributions-tab: % of schools that repeat cohorts (students starting in
+    # >= 2 distinct year-quarters), and % of GRADUATE feedback respondents who
+    # said they're "likely" to keep contributing.
+    repeat_total = len(inst_quarters)
+    repeat_count = sum(1 for qs in inst_quarters.values() if len(qs) >= 2)
+    repeat_schools = {
+        "pct": round(100 * repeat_count / repeat_total) if repeat_total else None,
+        "count": repeat_count, "total": repeat_total,
+    }
+    grad_keep = []
+    for r in feedback_records:
+        fem = get_field_value(r, FIELDS["feedback"]["email"])
+        if fem and fem.strip().lower() in grad_emails:
+            k = status_key(get_field_value(r, FIELDS["feedback"]["keep"]))
+            if k:
+                grad_keep.append(k)
+    keep_contributing_grads = (
+        {"pct": round(100 * sum(1 for k in grad_keep if k == "likely") / len(grad_keep)), "n": len(grad_keep)}
+        if grad_keep else {"pct": None, "n": 0}
+    )
+
     # Build global stats
     global_stats = {
         "activeStudents": active_count,
@@ -894,6 +944,11 @@ def main():
         "instCountries": inst_countries,
         "mentorCountries": mentor_countries,
         "fieldOfStudy": field_of_study_stats,
+        "firstContributions": first_contributions,
+        "eventParticipants": event_participants,
+        "sitesCreated": sites_created,
+        "repeatSchools": repeat_schools,
+        "keepContributingGrads": keep_contributing_grads,
     }
 
     # Translation totals from WordPress.org profile scraping

--- a/scripts/template.html
+++ b/scripts/template.html
@@ -323,27 +323,26 @@ function tc(name){return TEAM_COLORS[name]||'#546e7a';}
 // ─── SECTION 2: CONTRIBUTIONS ─────────────────────────
 (function(){
   const el = document.getElementById('sec-contributions');
-  const t = D.translationTotals;
-  const transStudents = D.students.filter(s => s.total_strings > 0).length;
-  
-  el.innerHTML = '<div class="cards">' +
-    '<div class="card"><div class="num">' + (t.total||0).toLocaleString() + '</div><div class="lbl">Translation Strings</div></div>' +
-    '<div class="card"><div class="num">' + transStudents + '</div><div class="lbl">Translating Students</div></div>' +
-  '</div>' +
-  '<div class="chart-container"><h3>Translation Activity</h3><div class="trans-chart-wrap"><div class="donut-container" id="dC"></div><div class="legend" id="dL"></div></div></div>';
-
-  // Translation donut chart
-  function drawDonut(sg, tr, rv) {
-    var tot = sg + tr + rv;
-    if (!tot) { document.getElementById('dC').innerHTML = '<div class="no-data">No data</div>'; document.getElementById('dL').innerHTML = ''; return; }
-    var segs = [{v:sg,c:'#0073aa',l:'Suggested'},{v:tr,c:'#00a32a',l:'Translated'},{v:rv,c:'#9b59b6',l:'Reviewed'}];
-    var r=90,cx=110,cy=110,sw=30,ci=2*Math.PI*r; var o=0,p='';
-    segs.forEach(function(s){ if(!s.v)return; var dl=ci*s.v/tot; p+='<circle cx="'+cx+'" cy="'+cy+'" r="'+r+'" fill="none" stroke="'+s.c+'" stroke-width="'+sw+'" stroke-dasharray="'+dl+' '+(ci-dl)+'" stroke-dashoffset="'+(-o)+'" transform="rotate(-90 '+cx+' '+cy+')"/>'; o+=dl; });
-    document.getElementById('dC').innerHTML = '<svg viewBox="0 0 220 220">' + p + '</svg><div class="donut-center"><div class="big">' + tot.toLocaleString() + '</div><div class="sub">Strings</div></div>';
-    document.getElementById('dL').innerHTML = segs.map(function(s){ return '<div class="legend-item"><div class="legend-dot" style="background:'+s.c+'"></div><div><div class="legend-num">'+s.v.toLocaleString()+'</div><div style="font-size:12px;color:var(--text-light)">'+s.l+'</div></div></div>'; }).join('');
-  }
-  drawDonut(t.suggested, t.translated, t.reviewed);
-
+  const g = D.global;
+  const teamsReceiving = Object.keys(g.teamDistribution || {}).length;
+  const grad = g.graduates || 0, drop = g.dropouts || 0;
+  const gradRate = (grad + drop) > 0 ? Math.round(grad / (grad + drop) * 100) : null;
+  const rs = g.repeatSchools || {}, kg = g.keepContributingGrads || {};
+  const n = v => (v || 0).toLocaleString();
+  const pct = v => (v != null ? v + '%' : '—');
+  const card = (num, lbl, sub) => '<div class="card"><div class="num">' + num + '</div><div class="lbl">' + lbl + '</div>' + (sub ? '<div class="act-sub">' + sub + '</div>' : '') + '</div>';
+  el.innerHTML = ''
+    + '<p class="chart-sub" style="margin:2px 0 18px">What students produce through the program, and how it carries forward — program-wide totals.</p>'
+    + '<div class="cards">'
+    +   card(n(g.firstContributions), 'First contributions made')
+    +   card(n(g.sitesCreated), 'WordPress sites created')
+    +   card(n(g.eventParticipants), 'Took part in WordPress events')
+    +   card(n(g.totalCourses), 'Courses completed on Learn')
+    +   card(teamsReceiving, 'WordPress teams contributed to')
+    +   card(pct(gradRate), 'Graduation rate', 'of everyone who finished')
+    +   card(pct(kg.pct), 'Graduates who’ll keep contributing')
+    +   card(pct(rs.pct), 'Schools that run repeat cohorts')
+    + '</div>';
 })();
 // Feedback section (aggregate, experience-only)
 (function(){


### PR DESCRIPTION
Replaces the Contributions tab (translation totals + donut) with **eight aggregate impact metrics** you asked for, and computes the new ones in the build.

## The tab (live-data values)
| Metric | Value | Source |
|---|---|---|
| First contributions made | 298 | first-contribution reflections — **new** |
| WordPress sites created | 441 | personal website URL — **new** |
| Took part in WordPress events | 210 | event-participation URL — **new** |
| Courses completed on Learn | 2,920 | existing `totalCourses` |
| WordPress teams contributed to | 13 | distinct teams (existing) |
| Graduation rate (of those who finished) | 87% | existing graduates/dropouts |
| Graduates who'll keep contributing | 78% | **new** — % of *graduate* feedback respondents who said "likely" |
| Schools that run repeat cohorts | 38% | **new** — schools with students starting in ≥2 distinct year-quarters |

All **aggregate / anonymous**, consistent with the privacy stance. The translation-strings total is dropped from this tab (it still lives on the Overview).

## Notes
- "Repeat cohorts" quarters = Jan–Mar / Apr–Jun / Jul–Sep / Oct–Dec; a school "repeats" if its students span ≥2 distinct year-quarters *over time*.
- "Keep contributing" is scoped to graduates by matching feedback email → graduate status; denominator is graduate *respondents*.
- Numbers above are from a preview against today's data; the live values come from the build and may shift by a hair on the next refresh.
- Post-graduation **actual** contribution tracking is scoped separately in #137.

## Validation
Rendered in-browser: 8 cards render with correct values in the new design, no console errors. `build_dashboard.py` compiles.

Part of #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)