### PR TITLE
Design pass 2: repaint categorical chart colours to the palette

### DIFF
--- a/scripts/template.html
+++ b/scripts/template.html
@@ -169,7 +169,7 @@ function initInstMap() {
 
   const wpIcon = L.divIcon({
     className: 'wp-marker',
-    html: '<div style="background:#0073aa;width:28px;height:28px;border-radius:50%;border:3px solid #fff;box-shadow:0 2px 6px rgba(0,0,0,.35);display:flex;align-items:center;justify-content:center;color:#fff;font-weight:700;font-size:13px;font-family:dashicons,sans-serif"></div>',
+    html: '<div style="background:#3858E9;width:28px;height:28px;border-radius:50%;border:3px solid #fff;box-shadow:0 2px 6px rgba(0,0,0,.35);display:flex;align-items:center;justify-content:center;color:#fff;font-weight:700;font-size:13px;font-family:dashicons,sans-serif"></div>',
     iconSize: [28, 28],
     iconAnchor: [14, 14],
     popupAnchor: [0, -16]
@@ -178,7 +178,7 @@ function initInstMap() {
   const wpIconMulti = function(count) {
     return L.divIcon({
       className: 'wp-marker',
-      html: '<div style="background:#0073aa;width:32px;height:32px;border-radius:50%;border:3px solid #fff;box-shadow:0 2px 6px rgba(0,0,0,.35);display:flex;align-items:center;justify-content:center;color:#fff;font-weight:800;font-size:14px">' + count + '</div>',
+      html: '<div style="background:#3858E9;width:32px;height:32px;border-radius:50%;border:3px solid #fff;box-shadow:0 2px 6px rgba(0,0,0,.35);display:flex;align-items:center;justify-content:center;color:#fff;font-weight:800;font-size:14px">' + count + '</div>',
       iconSize: [32, 32],
       iconAnchor: [16, 16],
       popupAnchor: [0, -18]
@@ -217,8 +217,9 @@ document.querySelectorAll('.nav-item').forEach(tab => {
 });
 
 // Team color helper
-const TEAM_COLORS={"Polyglots":"#1b5e20","Documentation":"#0d47a1","Photos":"#4a148c","Design":"#e65100","Core":"#b71c1c","Community":"#00695c","Mobile":"#283593","TV":"#4e342e","Training":"#f57f17","Plugins":"#1565c0","Support":"#2e7d32","Test":"#c62828","Themes":"#6a1b9a"};
-function tc(name){return TEAM_COLORS[name]||'#546e7a';}
+// Categorical palette tuned to the warm page + brand blue/green/amber.
+const TEAM_COLORS={"Polyglots":"#2F7D5B","Documentation":"#3858E9","Photos":"#6B4E9E","Design":"#C0563A","Core":"#2743B4","Community":"#2A7B8C","Mobile":"#4E7A9E","TV":"#8A5A3C","Training":"#B07A22","Plugins":"#5F6B7A","Support":"#6E7B36","Test":"#A34568","Themes":"#8C6D1F"};
+function tc(name){return TEAM_COLORS[name]||'#857C6E';}
 
 // ─── SECTION 1: GLOBAL ───────────────────────────────
 (function(){
@@ -306,14 +307,15 @@ function tc(name){return TEAM_COLORS[name]||'#546e7a';}
   });
   const fosEntries = Object.entries(fosMap).map(([k,v]) => [k, v.active + v.graduated, v.active, v.graduated]).sort((a,b) => b[1] - a[1]);
   const fosTotal = fosEntries.reduce((a,e) => a + e[1], 0);
-  const fosColors = {'Technology & Engineering':'#0073aa','Languages, Communication & Writing':'#00a32a','Business, Marketing & Management':'#dba617','Design & Creative Media':'#9b59b6','Humanities & Social Sciences':'#e67e22','Arts & Architecture':'#d63638','Unspecified':'#546e7a'};
+  // Covers every "Your field of study" option in Airtable, so none fall back to grey.
+  const fosColors = {'Technology & Engineering':'#3858E9','Design & Creative Media':'#6B4E9E','Languages, Communication & Writing':'#2F7D5B','Education & Learning':'#2A7B8C','Business, Marketing & Management':'#B07A22','Humanities & Social Sciences':'#C0563A','Arts & Architecture':'#A34568','Natural Sciences & Mathematics':'#6E7B36','Health & Medicine':'#4E7A9E','Unspecified':'#857C6E'};
   const fosR=70,fosCx=90,fosCy=90,fosSw=24,fosCI=2*Math.PI*fosR;
   let fosOff=0,fosPaths='';
-  fosEntries.forEach(([n,c])=>{if(!c)return;const dl=fosCI*c/fosTotal;fosPaths+=`<circle cx="${fosCx}" cy="${fosCy}" r="${fosR}" fill="none" stroke="${fosColors[n]||'#546e7a'}" stroke-width="${fosSw}" stroke-dasharray="${dl} ${fosCI-dl}" stroke-dashoffset="${-fosOff}" transform="rotate(-90 ${fosCx} ${fosCy})"/>`;fosOff+=dl;});
+  fosEntries.forEach(([n,c])=>{if(!c)return;const dl=fosCI*c/fosTotal;fosPaths+=`<circle cx="${fosCx}" cy="${fosCy}" r="${fosR}" fill="none" stroke="${fosColors[n]||'#857C6E'}" stroke-width="${fosSw}" stroke-dasharray="${dl} ${fosCI-dl}" stroke-dashoffset="${-fosOff}" transform="rotate(-90 ${fosCx} ${fosCy})"/>`;fosOff+=dl;});
   const fosLegend = fosEntries.map(([n,c,act,grad]) => {
     const pct = fosTotal ? Math.round(c/fosTotal*100) : 0;
-    const gradNote = grad > 0 ? ` <span style="color:#e65100;font-size:11px">(${grad} grad.)</span>` : '';
-    return `<div style="display:flex;align-items:center;gap:10px;padding:7px 0;border-bottom:1px solid #f0f0f1"><div style="width:14px;height:14px;border-radius:4px;background:${fosColors[n]||'#546e7a'};flex-shrink:0"></div><div style="flex:1;min-width:0"><div style="font-size:13px;font-weight:500;color:var(--text)">${n}</div></div><div style="font-size:15px;font-weight:700;color:var(--text);white-space:nowrap">${c} <span style="font-size:11px;font-weight:400;color:var(--text-light)">(${pct}%)</span>${gradNote}</div></div>`;
+    const gradNote = grad > 0 ? ` <span style="color:#B07A22;font-size:11px">(${grad} grad.)</span>` : '';
+    return `<div style="display:flex;align-items:center;gap:10px;padding:7px 0;border-bottom:1px solid var(--border)"><div style="width:14px;height:14px;border-radius:4px;background:${fosColors[n]||'#857C6E'};flex-shrink:0"></div><div style="flex:1;min-width:0"><div style="font-size:13px;font-weight:500;color:var(--text)">${n}</div></div><div style="font-size:15px;font-weight:700;color:var(--text);white-space:nowrap">${c} <span style="font-size:11px;font-weight:400;color:var(--text-light)">(${pct}%)</span>${gradNote}</div></div>`;
   }).join('');
   document.getElementById('fosChart').innerHTML = `<div style="display:flex;gap:24px;align-items:center;flex-wrap:wrap"><div style="width:180px;height:180px;position:relative;flex-shrink:0"><svg viewBox="0 0 180 180">${fosPaths}</svg><div style="position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);text-align:center"><div style="font-size:24px;font-weight:800;color:var(--text)">${fosTotal}</div><div style="font-size:10px;color:var(--text-light);text-transform:uppercase">Students</div></div></div><div style="flex:1;min-width:200px">${fosLegend}</div></div>`;
     // Maps
@@ -354,9 +356,9 @@ function tc(name){return TEAM_COLORS[name]||'#546e7a';}
   var barW = function(o){ return (o && o.avg!=null) ? Math.round(o.avg/5*100) : 0; };
   var ratingCard = function(title,o){ return '<div class="chart-container"><h3>'+title+'</h3>'
     + '<div style="font-size:22px;font-weight:800;color:var(--text);margin-bottom:8px">'+rat(o)+' <span style="font-size:13px;color:var(--text-light);font-weight:400">/ 5</span></div>'
-    + '<div style="height:6px;border-radius:3px;background:var(--border)"><div style="width:'+barW(o)+'%;height:6px;border-radius:3px;background:#EF9F27"></div></div></div>'; };
+    + '<div style="height:6px;border-radius:3px;background:var(--border)"><div style="width:'+barW(o)+'%;height:6px;border-radius:3px;background:#B07A22"></div></div></div>'; };
   var c = fb.confidence.dist || {}, cn = fb.confidence.n || 1;
-  var confOrder = [['Very confident','#0F6E56'],['Confident','#5DCAA5'],['Neutral','#B4B2A9'],['Not very confident','#B07A22']];
+  var confOrder = [['Very confident','#2F7D5B'],['Confident','#7FB39A'],['Neutral','#C7BFB0'],['Not very confident','#B07A22']];
   var seg = confOrder.map(function(x){ var v=c[x[0]]||0; return v? '<div style="width:'+(v/cn*100)+'%;background:'+x[1]+'"></div>':''; }).join('');
   var leg = confOrder.map(function(x){ var v=c[x[0]]||0; return '<span style="display:flex;align-items:center;gap:5px"><span style="width:10px;height:10px;border-radius:2px;background:'+x[1]+'"></span>'+x[0]+' '+Math.round(v/cn*100)+'%</span>'; }).join('');
   var voices = [


### PR DESCRIPTION
Second and final design pass — brings the remaining charts onto the warm palette from #136. Template-only.

## Changes
- **Team bars** — the 13 dark wp-admin colours replaced with a harmonised categorical set (blue / green / amber / terracotta / plum / teal / rose / olive / …).
- **Field-of-study donut** — same categorical set, and it now covers **every** "Your field of study" option in Airtable.
- **Map pins** — old wp-admin blue → brand blue `#3858E9`.
- **Voices** — confidence ramp harmonised (palette green → light green → warm neutral → amber); rating bars use the palette amber.
- **Field-of-study legend** — the "(N grad.)" note and row divider moved off the old orange / cold grey.

## 🐛 Bug fixed along the way
`fosColors` was missing three options that exist in Airtable — **Education & Learning** (16 students), Natural Sciences & Mathematics, and Health & Medicine — so they rendered as anonymous grey. All options now have their own colour.

## Validation
Verified in-browser against live data: every chart colour resolves to the intended palette value (donut strokes, legend dots, team bars, map pins, confidence ramp, rating bars) and there are **no console errors**.

Part of #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)