### PR TITLE
Overview: add Skills unlocked, move "Who's joining us" up, drop contribution stats

### DIFF
--- a/scripts/template.html
+++ b/scripts/template.html
@@ -58,6 +58,13 @@ h1,h2,h3,h4{font-family:var(--serif);font-weight:600}
 .act-scale{color:var(--wp-blue)}
 .act-contribution{color:var(--wp-green)}
 .act-outcomes{color:var(--wp-orange)}
+.act-skills{color:var(--wp-green)}
+.skills-grid{display:grid;grid-template-columns:1fr 1fr;gap:28px}
+@media(max-width:760px){.skills-grid{grid-template-columns:1fr}}
+.skills-head{font-size:12px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--text-light);margin-bottom:12px}
+.skills-chips{display:flex;flex-wrap:wrap;gap:8px}
+.skill{display:inline-block;padding:7px 14px;border-radius:20px;font-size:13px;font-weight:500;background:var(--blue-tint);color:var(--blue-ink)}
+.skills-transferable .skill{background:var(--green-tint);color:#1F5C43}
 .bar-chart{display:flex;flex-direction:column;gap:10px}
 .bar-row{display:flex;align-items:center;gap:12px}
 .bar-label{width:130px;text-align:right;font-size:13px;font-weight:500;color:var(--text);flex-shrink:0}
@@ -218,16 +225,12 @@ document.querySelectorAll('.nav-item').forEach(tab => {
 
 // Team color helper
 // Categorical palette tuned to the warm page + brand blue/green/amber.
-const TEAM_COLORS={"Polyglots":"#2F7D5B","Documentation":"#3858E9","Photos":"#6B4E9E","Design":"#C0563A","Core":"#2743B4","Community":"#2A7B8C","Mobile":"#4E7A9E","TV":"#8A5A3C","Training":"#B07A22","Plugins":"#5F6B7A","Support":"#6E7B36","Test":"#A34568","Themes":"#8C6D1F"};
-function tc(name){return TEAM_COLORS[name]||'#857C6E';}
 
 // ─── SECTION 1: GLOBAL ───────────────────────────────
 (function(){
   const g = D.global;
   const el = document.getElementById('sec-global');
   // Derived figures for the restructured, story-first Overview.
-  const transTotal = (D.translationTotals && D.translationTotals.total) || 0;
-  const teamCount = Object.keys(g.teamDistribution || {}).length;
   const countryCount = Object.keys(g.instCountries || {}).length;
   // Graduation rate — show both: completion among those who reached an outcome,
   // with a context line for how many are still in-program. "Not moving forward"
@@ -258,14 +261,34 @@ function tc(name){return TEAM_COLORS[name]||'#857C6E';}
       <div style="position:relative;height:320px"><canvas id="growthChart"></canvas></div>
     </div>
     <div class="chart-container"><h3>Where our partners are</h3><div class="chart-sub">Partner institutions around the world</div><div id="instMap"></div></div>
+    <div class="chart-container"><h3>Who's joining us</h3><div class="chart-sub">The academic backgrounds students bring</div><div id="fosChart"></div></div>
 
-    <div class="act-label act-contribution">Real contribution</div>
-    <div class="cards">
-      <div class="card"><div class="num">${g.totalHours.toLocaleString()}</div><div class="lbl">Contribution Hours</div></div>
-      <div class="card"><div class="num">${transTotal.toLocaleString()}</div><div class="lbl">Translation Strings</div></div>
-      <div class="card"><div class="num">${teamCount}</div><div class="lbl">Contribution Teams</div></div>
+    <div class="act-label act-skills">Skills unlocked</div>
+    <div class="chart-container">
+      <div class="chart-sub" style="margin-bottom:18px">Technical and transferable skills students build through real open-source work.</div>
+      <div class="skills-grid">
+        <div>
+          <div class="skills-head">Technical</div>
+          <div class="skills-chips">
+            <span class="skill">Website building &amp; customization</span>
+            <span class="skill">Localization &amp; translation</span>
+            <span class="skill">Design &amp; visual media</span>
+            <span class="skill">Content &amp; documentation</span>
+            <span class="skill">Quality, testing &amp; accessibility</span>
+          </div>
+        </div>
+        <div class="skills-transferable">
+          <div class="skills-head">Transferable</div>
+          <div class="skills-chips">
+            <span class="skill">Open-source collaboration, tools &amp; workflow</span>
+            <span class="skill">Professional communication</span>
+            <span class="skill">Project &amp; time management</span>
+            <span class="skill">Giving &amp; receiving feedback</span>
+            <span class="skill">Public speaking &amp; community participation</span>
+          </div>
+        </div>
+      </div>
     </div>
-    <div class="chart-container"><h3>What students are contributing to</h3><div class="chart-sub">How many students work on each WordPress team</div><div class="bar-chart" id="teamChart"></div></div>
 
     <div class="act-label act-outcomes">Outcomes &amp; quality</div>
     <div class="cards">
@@ -273,7 +296,6 @@ function tc(name){return TEAM_COLORS[name]||'#857C6E';}
       <div class="card"><div class="num">${recPct}</div><div class="lbl">Would Recommend</div></div>
       <div class="card"><div class="num">${keepPct}</div><div class="lbl">Keep Contributing</div></div>
     </div>
-    <div class="chart-container"><h3>Who's joining us</h3><div class="chart-sub">The academic backgrounds students bring</div><div id="fosChart"></div></div>
   `;
   // Growth over time (joining vs graduating, by month)
   (function(){
@@ -291,10 +313,6 @@ function tc(name){return TEAM_COLORS[name]||'#857C6E';}
           y1:{ position:'right', beginAtZero:true, grid:{ drawOnChartArea:false }, title:{ display:true, text:'cumulative' } } } }
     });
   })();
-  // Team chart
-  const teams = Object.entries(g.teamDistribution).sort((a,b) => b[1]-a[1]);
-  const mx = teams[0]?teams[0][1]:1;
-  document.getElementById('teamChart').innerHTML = teams.map(([n,c]) => `<div class="bar-row"><div class="bar-label">${n}</div><div class="bar-track"><div class="bar-fill" style="width:${Math.max(c/mx*100,8)}%;background:${tc(n)}">${c}</div></div></div>`).join('');
   // Field of Study chart (computed dynamically from student data)
   const activeStatuses = new Set(['in sensei','in sensei self-onboarding','in sensei 50h','pending graduation']);
   const fosMap = {};


### PR DESCRIPTION
Reworks the Overview to lead with **reach and skills** rather than contribution volume (those numbers already live on the Contributions tab).

## Changes
- **New "Skills unlocked" act**, replacing "Real contribution" — ten skills as chips in two columns:
  - **Technical** — website building & customization · localization & translation · design & visual media · content & documentation · quality, testing & accessibility
  - **Transferable** — open-source collaboration, tools & workflow · professional communication · project & time management · giving & receiving feedback · public speaking & community participation
- **"Who's joining us"** (field-of-study) moved up to sit right after the partners map, inside *Scale & momentum*.
- **Removed** the Contribution Hours, Translation Strings and Contribution Teams cards, plus the "What students are contributing to" team-bars chart. First-contributions and teams-receiving stay on the **Contributions tab** rather than being duplicated here.
- **Cleaned up the code they left behind**: the team-bars renderer, `TEAM_COLORS` / `tc()`, and the `transTotal` / `teamCount` variables.

New Overview flow: **Scale & momentum** (cards → growth → partners → who's joining us) → **Skills unlocked** → **Outcomes & quality**.

## Skills grounding
The list is derived from the actual 11-course curriculum and the 14 contribution teams, consolidated into umbrellas. Deliberately shown **without numbers** — only some skills have backing data (team-derived), so counts would imply precision we don't have for the transferable ones.

## Validation
Verified in-browser against live data: section order is correct, both skill columns render as styled chips in a 2×570px grid, the field-of-study donut still draws, the team chart is gone, and there are **no console errors**.

Part of #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)