### PR TITLE
Fix CNM alias never matching in repeat-cohort grouping

### DIFF
--- a/scripts/build_dashboard.py
+++ b/scripts/build_dashboard.py
@@ -496,8 +496,10 @@ def main():
 
     # Institutions tracked separately in Airtable (for reasons unrelated to this
     # dashboard) that are the same partner for repeat-cohort purposes.
+    # Keys are lowercased: names reach us through title_case(), which does not
+    # preserve acronyms ("CNM Ingenuity" -> "Cnm Ingenuity"), so match loosely.
     INSTITUTION_ALIASES = {
-        "CNM Ingenuity": "Central New Mexico Community College",
+        "cnm ingenuity": "Central New Mexico Community College",
     }
 
     # Process students
@@ -579,7 +581,7 @@ def main():
             )
             if fc_sd:
                 fc_name = institutions_lookup[fc_inst[0]]["name"]
-                fc_name = INSTITUTION_ALIASES.get(fc_name, fc_name)
+                fc_name = INSTITUTION_ALIASES.get(fc_name.strip().lower(), fc_name)
                 inst_quarters.setdefault(fc_name, set()).add((fc_sd.year, (fc_sd.month - 1) // 3))
 
         # Skip students with non-active statuses (Not moving forward, SPAM, Dropped out, Paused, etc.)


### PR DESCRIPTION
Follow-up to #144, part of #108.

#144 shipped, but the repeat-cohorts figure came out at **47% (8/17)** instead of the intended **53% (9/17)**.

**Cause:** institution names reach the repeat-cohort grouping through `title_case()`, which — despite its docstring saying it preserves acronyms — turns `"CNM Ingenuity"` into `"Cnm Ingenuity"`. The alias map added in #144 was keyed on the raw Airtable name, so it never matched, and the two CNM records stayed separate.

**Fix:** key the alias map on the lowercased name and match case-insensitively.

### Note on `title_case()`

Mangling acronyms is a broader bug (`IES`, `RMIT`, `AAB`, `UDIT` would be affected too), but it is **no longer publicly visible** — institution names were dropped from the public data blob in #132, so `title_case()` now only affects internal aggregation. Not fixing it here to keep this change small; worth a separate issue if we ever put institution names back on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)