### PR TITLE
Drop the three Contributions cards that repeat the Overview

### DIFF
--- a/scripts/build_dashboard.py
+++ b/scripts/build_dashboard.py
@@ -109,7 +109,6 @@ FIELDS = {
     },
     # Student feedback (student-linked layer). Aggregate, experience-only.
     "feedback": {
-        "email": "fldJcJQSgPIJ7XamR",          # used only to scope "keep" to graduates
         "ease": "fldn7M6U4xXurEgJ2",          # rating 1-5
         "satisfaction": "fldJPTEix369b8NOw",   # rating 1-5
         "impact": "fldxtEUsunNgjyKXV",         # rating 1-5
@@ -518,7 +517,6 @@ def main():
     event_participants = 0
     sites_created = 0
     inst_quarters = {}   # institution name -> set of (year, quarter) students started in
-    grad_emails = set()  # emails of graduates, to scope "keep contributing" feedback
 
     for rec in students_reports_records:
         name = get_field_value(rec, FIELDS["students_reports"]["name"])
@@ -618,8 +616,6 @@ def main():
         email_key = report_email.strip().lower() if report_email else ""
         name_normalized = " ".join(name.strip().lower().split()) if name else ""
         student_rec = students_by_email.get(email_key) or students_by_name.get(name_normalized)
-        if is_graduate and email_key:
-            grad_emails.add(email_key)
         if student_rec:
             fos_obj = get_field_value(student_rec, FIELDS["students"]["field_of_study"])
             if fos_obj and isinstance(fos_obj, dict):
@@ -925,8 +921,7 @@ def main():
     }
 
     # % of schools that repeat cohorts (students starting in >= 2 distinct
-    # year-quarters), and % of GRADUATE feedback respondents who said they're
-    # "likely" to keep contributing.
+    # year-quarters).
     #
     # Schools whose *first* cohort is the quarter we're currently in are excluded
     # from the denominator: they have not yet had the opportunity to return, so
@@ -945,18 +940,6 @@ def main():
         # Schools too new to have repeated yet, excluded from the ratio above.
         "tooNew": len(inst_quarters) - repeat_total,
     }
-    grad_keep = []
-    for r in feedback_records:
-        fem = get_field_value(r, FIELDS["feedback"]["email"])
-        if fem and fem.strip().lower() in grad_emails:
-            k = status_key(get_field_value(r, FIELDS["feedback"]["keep"]))
-            if k:
-                grad_keep.append(k)
-    keep_contributing_grads = (
-        {"pct": round(100 * sum(1 for k in grad_keep if k == "likely") / len(grad_keep)), "n": len(grad_keep)}
-        if grad_keep else {"pct": None, "n": 0}
-    )
-
     # Build global stats
     global_stats = {
         "activeStudents": active_count,
@@ -977,7 +960,6 @@ def main():
         "eventParticipants": event_participants,
         "sitesCreated": sites_created,
         "repeatSchools": repeat_schools,
-        "keepContributingGrads": keep_contributing_grads,
     }
 
     # Translation totals from WordPress.org profile scraping

--- a/scripts/template.html
+++ b/scripts/template.html
@@ -317,12 +317,8 @@ document.querySelectorAll('.nav-item').forEach(tab => {
   const el = document.getElementById('sec-contributions');
   const g = D.global;
   const teamsReceiving = Object.keys(g.teamDistribution || {}).length;
-  const grad = g.graduates || 0, drop = g.dropouts || 0;
-  const gradRate = (grad + drop) > 0 ? Math.round(grad / (grad + drop) * 100) : null;
-  const rs = g.repeatSchools || {}, kg = g.keepContributingGrads || {};
   const n = v => (v || 0).toLocaleString();
-  const pct = v => (v != null ? v + '%' : '—');
-  const card = (num, lbl, sub) => '<div class="card"><div class="num">' + num + '</div><div class="lbl">' + lbl + '</div>' + (sub ? '<div class="act-sub">' + sub + '</div>' : '') + '</div>';
+  const card = (num, lbl) => '<div class="card"><div class="num">' + num + '</div><div class="lbl">' + lbl + '</div></div>';
   el.innerHTML = ''
     + '<p class="chart-sub" style="margin:2px 0 18px">What students produce through the program, and how it carries forward — program-wide totals.</p>'
     + '<div class="cards">'
@@ -331,9 +327,6 @@ document.querySelectorAll('.nav-item').forEach(tab => {
     +   card(n(g.eventParticipants), 'Took part in WordPress events')
     +   card(n(g.totalCourses), 'Courses completed on Learn')
     +   card(teamsReceiving, 'WordPress teams contributed to')
-    +   card(pct(gradRate), 'Graduation rate', 'of everyone who finished')
-    +   card(pct(kg.pct), 'Graduates who’ll keep contributing')
-    +   card(pct(rs.pct), 'Schools that run repeat cohorts', rs.total ? 'of the ' + rs.total + ' with us long enough to return' : '')
     + '</div>';
 })();
 // Feedback section (aggregate, experience-only)


### PR DESCRIPTION
Part of #108.

Graduation rate, graduates who'll keep contributing, and schools that run repeat cohorts all moved into **Overview → Outcomes & quality** in #144. The Contributions tab was still showing the same three numbers one click away from themselves.

**Contributions is now five cards**, all things the tab is actually about — what students produced:

| | |
|---|---|
| 317 | First contributions made |
| 446 | WordPress sites created |
| 232 | Took part in WordPress events |
| 2,966 | Courses completed on Learn |
| 14 | WordPress teams contributed to |

### Knock-on cleanup

Removing the keep-contributing card orphaned **`keepContributingGrads`**, which existed only to feed it, so the build no longer computes or publishes it.

The two "78%" figures were scoped differently, so worth recording why the Overview's survives:

- `keepContributingGrads` (n=131) — feedback filtered to respondents whose Airtable status literally reads "Graduate"
- `feedback.keep` (n=146) — everyone who answered the question

Both reported 78%. `feedback.keep` is the better measure here: only finishers are sent that form, so its extra 15 responses are real finishers whose status simply hasn't caught up yet. It also keeps the card consistent with the "would recommend" card beside it, which has no graduate-scoped variant.

That in turn orphaned the Feedback table's **`email`** field mapping, whose only consumer was the graduate scoping. Dropped too — one less field to 422 on if Airtable changes, and the build no longer pulls student emails it has no use for.

**Verified** against live data: Contributions renders five cards on one row, Overview and Voices unchanged, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)