### PR TITLE
Voices: stop overstating the sample, drop the Overview duplicates

### DIFF
--- a/scripts/build_dashboard.py
+++ b/scripts/build_dashboard.py
@@ -909,7 +909,11 @@ def main():
             conf_n += 1
 
     feedback = {
-        "responses": len(feedback_records),
+        # NOTE: deliberately no overall "responses" count. len(feedback_records)
+        # counts ROWS in the Feedback table, and a row is pre-created for every
+        # student whether or not they ever answer — so it ran ~3-4x higher than
+        # any question's real response count and overstated the sample. Each
+        # metric now carries its own n, which is the only honest denominator.
         "ratings": {
             "ease": _rating_avg("ease"),
             "satisfaction": _rating_avg("satisfaction"),

--- a/scripts/template.html
+++ b/scripts/template.html
@@ -333,13 +333,18 @@ document.querySelectorAll('.nav-item').forEach(tab => {
 (function(){
   var fb = D.feedback, el = document.getElementById('sec-feedback');
   if (!el) return;
-  if (!fb || !fb.responses) { el.innerHTML = '<div class="chart-container"><h3>Student Feedback</h3><p style="color:var(--text-light)">No feedback yet.</p></div>'; return; }
-  var pct = function(o){ return (o && o.pct!=null) ? o.pct+'%' : '—'; };
+  // Every figure carries its own response count: each question sits on a
+  // different form, so no two are answered by the same set of students. This is
+  // also the gate — a real answered-question count, never a table row count.
+  var nOf = function(o){ return (o && o.n) || 0; };
+  var hasAnswers = fb && (nOf(fb.ratings && fb.ratings.ease) || nOf(fb.ratings && fb.ratings.satisfaction) || nOf(fb.confidence));
+  if (!hasAnswers) { el.innerHTML = '<div class="chart-container"><h3>Student Feedback</h3><p style="color:var(--text-light)">No feedback yet.</p></div>'; return; }
   var rat = function(o){ return (o && o.avg!=null) ? o.avg.toFixed(1) : '—'; };
   var barW = function(o){ return (o && o.avg!=null) ? Math.round(o.avg/5*100) : 0; };
   var ratingCard = function(title,o){ return '<div class="chart-container"><h3>'+title+'</h3>'
     + '<div style="font-size:22px;font-weight:800;color:var(--text);margin-bottom:8px">'+rat(o)+' <span style="font-size:13px;color:var(--text-light);font-weight:400">/ 5</span></div>'
-    + '<div style="height:6px;border-radius:3px;background:var(--border)"><div style="width:'+barW(o)+'%;height:6px;border-radius:3px;background:#B07A22"></div></div></div>'; };
+    + '<div style="height:6px;border-radius:3px;background:var(--border)"><div style="width:'+barW(o)+'%;height:6px;border-radius:3px;background:#B07A22"></div></div>'
+    + '<div style="margin-top:8px;font-size:12px;color:var(--text-light)">'+nOf(o)+' responses</div></div>'; };
   var c = fb.confidence.dist || {}, cn = fb.confidence.n || 1;
   var confOrder = [['Very confident','#2F7D5B'],['Confident','#7FB39A'],['Neutral','#C7BFB0'],['Not very confident','#B07A22']];
   var seg = confOrder.map(function(x){ var v=c[x[0]]||0; return v? '<div style="width:'+(v/cn*100)+'%;background:'+x[1]+'"></div>':''; }).join('');
@@ -357,21 +362,17 @@ document.querySelectorAll('.nav-item').forEach(tab => {
     + '<h3 style="font-size:18px;margin:4px 0 6px">Voices from the program</h3>'
     + '<p style="font-size:13px;color:var(--text-light);margin:0 0 18px">In students’ own words, shared with their consent.</p>'
     + '<div class="voices-grid">' + voicesHtml + '</div>'
-    + '<h3 style="font-size:18px;margin:32px 0 14px">How students rate the experience</h3>'
-    + '<div class="cards">'
-    +   '<div class="card"><div class="num">'+pct(fb.recommend)+'</div><div class="lbl">Would recommend WP Credits</div></div>'
-    +   '<div class="card"><div class="num">'+pct(fb.keep)+'</div><div class="lbl">Will keep contributing</div></div>'
-    + '</div>'
+    + '<h3 style="font-size:18px;margin:32px 0 6px">How the program felt along the way</h3>'
+    + '<p style="font-size:13px;color:var(--text-light);margin:0 0 14px">Students answer at different points in the program, so each figure has its own response count.</p>'
     + '<div class="charts-row">'
     +   ratingCard('Ease of getting started', fb.ratings.ease)
     +   ratingCard('Project / website satisfaction', fb.ratings.satisfaction)
-    +   ratingCard('Perceived impact', fb.ratings.impact)
     + '</div>'
     + '<div class="chart-container"><h3>Confidence contributing</h3>'
-    +   '<p style="margin:0 0 8px;font-size:12px;color:var(--text-light)">Asked after picking the contribution team, before contributing begins.</p>'
     +   '<div style="display:flex;height:22px;border-radius:6px;overflow:hidden">'+seg+'</div>'
-    +   '<div style="display:flex;flex-wrap:wrap;gap:14px;margin-top:8px;font-size:12px;color:var(--text-light)">'+leg+'</div></div>'
-    + '<p style="font-size:12px;color:var(--text-light);margin-top:12px">The metrics above are aggregated from '+fb.responses+' anonymous responses — no individual data shown.</p>';
+    +   '<div style="display:flex;flex-wrap:wrap;gap:14px;margin-top:8px;font-size:12px;color:var(--text-light)">'+leg+'</div>'
+    +   '<div style="margin-top:10px;font-size:12px;color:var(--text-light)">'+nOf(fb.confidence)+' responses</div></div>'
+    + '<p style="font-size:12px;color:var(--text-light);margin-top:12px">Aggregated from anonymous responses — no individual data shown. Graduation, recommendation and retention figures are on the Overview.</p>';
 })();
 </script>
 </body>


### PR DESCRIPTION
Part of #108. First half of the Voices rework — the honesty fixes. Themes treatment to follow separately.

### The sample size was overstated (the urgent one)

The footer claimed the metrics were **"aggregated from 692 anonymous responses."** They weren't. `responses` was `len(feedback_records)` — every **row** in the Feedback table — and per @CeliGaroe on #123, a row is pre-created for every student whether or not they ever answer.

Nothing on the page rested on 692:

| metric | real n |
|---|---|
| Ease of getting started | 221 |
| Perceived impact | 167 |
| Satisfaction · Would recommend · Confidence | 153 |
| Keep contributing | 149 |

So the claim overstated the sample by **3× to 4.5×** depending which metric you checked. On a page whose whole job is credibility, that was the worst number to have wrong.

**Fix:** the build no longer publishes an overall `responses` count at all — there is no honest single denominator, because each question sits on a different form and is answered by a different set of students. Every figure now carries its own n on the page. The "no feedback yet" guard was reading the same row count, so it now gates on a real answered-question count.

### Removed the three Overview duplicates

Would recommend, will keep contributing, and perceived impact have all lived on **Overview → Outcomes & quality** since #144 — the same duplication cleared off Contributions in #148.

### What's left

The part Voices uniquely tells: how the program felt *while students were in it*. Retitled **"How the program felt along the way"**, with a line pointing to the Overview for graduation, recommendation and retention.

- Ease of getting started — 4.0/5, 221 responses
- Project / website satisfaction — 4.5/5, 153 responses
- Confidence contributing — distribution, 153 responses

### One thing needing @peiraisotta

I dropped the confidence caption *"Asked after picking the contribution team, before contributing begins."* It contradicts the analysis in #123, which maps confidence to the **midway** form — and unlike the end-form questions, confidence respondents include dropouts. Rather than assert a stage I can't verify, the caption is gone and the response count stands in its place. Happy to restore a corrected version once you confirm which form it's on.

**Verified** against live data: 6 quotes, both rating cards with their counts, confidence distribution, no "692" anywhere, and the empty-feedback case still renders the "No feedback yet" fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)