### PR TITLE
Add partner-institution count + per-country breakdown; make the map data-driven

### DIFF
--- a/scripts/build_dashboard.py
+++ b/scripts/build_dashboard.py
@@ -118,33 +118,85 @@ FIELDS = {
     },
 }
 
-# Partner institution map markers, grouped by city. Coordinates geocoded from
-# city + country (one-time). Keep in sync with the partner list; if this grows
-# often, consider moving locations into Airtable and building markers from there.
-INST_MARKERS = [
-    {"city": "Dhaka", "country": "Bangladesh", "lat": 23.7644, "lng": 90.389, "institutions": ["Ahmad's Education"]},
-    {"city": "Pisa", "country": "Italy", "lat": 43.4715, "lng": 10.6798, "institutions": ["Università di Pisa"]},
-    {"city": "San José", "country": "Costa Rica", "lat": 9.9328, "lng": -84.0796, "institutions": ["Universidad Fidélitas"]},
-    {"city": "Cartago", "country": "Costa Rica", "lat": 9.8157, "lng": -83.6944, "institutions": ["Liceo HHC Experimental Bilingue José Figueres Ferrer"]},
-    {"city": "Albuquerque", "country": "United States", "lat": 35.0841, "lng": -106.651, "institutions": ["Central New Mexico Community College"]},
-    {"city": "Madison", "country": "United States", "lat": 40.7598, "lng": -74.4171, "institutions": ["Drew University"]},
-    {"city": "Riga", "country": "Latvia", "lat": 56.9494, "lng": 24.1052, "institutions": ["Riga Nordic University"]},
-    {"city": "Santa Cruz de la Sierra", "country": "Bolivia", "lat": -17.7834, "lng": -63.1821, "institutions": ["Universidad Privada Franz Tamayo"]},
-    {"city": "Cochabamba", "country": "Bolivia", "lat": -17.4012, "lng": -66.1676, "institutions": ["Universidad Privada Franz Tamayo"]},
-    {"city": "Kraków", "country": "Poland", "lat": 50.0619, "lng": 19.9369, "institutions": ["Krakow University of Economics", "Cracow University of Technology"]},
-    {"city": "Toledo", "country": "Spain", "lat": 39.8559, "lng": -4.0243, "institutions": ["IES Azarquiel", "Escuela de Arte Toledo"]},
-    {"city": "Madrid", "country": "Spain", "lat": 40.4168, "lng": -3.7035, "institutions": ["Creative Campus - Universidad Europea", "Universidad de Diseño Innovación y Tecnología - UDIT"]},
-    {"city": "Zaragoza", "country": "Spain", "lat": 41.6916, "lng": -0.9101, "institutions": ["Escuela de Arte de Zaragoza", "Zaragoza Dinámica"]},
-    {"city": "Huesca", "country": "Spain", "lat": 42.1361, "lng": -0.0298, "institutions": ["Escuela de Arte de Huesca"]},
-    {"city": "Estepona", "country": "Spain", "lat": 36.4268, "lng": -5.1468, "institutions": ["Instituto de Educación Secundaria Mar de Alborán"]},
-    {"city": "Salamanca", "country": "Spain", "lat": 40.9652, "lng": -5.664, "institutions": ["IES Venancio Blanco"]},
-    {"city": "A Coruña", "country": "Spain", "lat": 43.3466, "lng": -8.4127, "institutions": ["CPR Liceo La Paz"]},
-    {"city": "Kolhapur", "country": "India", "lat": 16.7028, "lng": 74.2405, "institutions": ["D Y Patil Agriculture and Technical University, Talsande, Kolhapur"]},
-    {"city": "Kolkata", "country": "India", "lat": 22.5726, "lng": 88.3639, "institutions": ["ERAP Research and Learning LLP"]},
-    {"city": "Pula", "country": "Croatia", "lat": 44.8702, "lng": 13.8455, "institutions": ["Juraj Dobrila University of Pula"]},
-    {"city": "Kampala", "country": "Uganda", "lat": 0.3177, "lng": 32.5814, "institutions": ["E-zone School of Computing"]},
-    {"city": "Helsinki", "country": "Finland", "lat": 60.1666, "lng": 24.9435, "institutions": ["Haaga-Helia University of Applied Sciences"]},
-]
+# City coordinates for the partner map. The map markers are generated at build
+# time from the CONFIRMED institutions (see build_inst_markers), so the map,
+# the partner-institution count and the per-country breakdown can never disagree
+# — they all read the same confirmed set. This table only supplies a location.
+#
+# Keyed by (lowercased city, resolved country) so Airtable's inconsistent casing
+# ("KOLHAPUR", "madrid", "TOLEDO") all resolve. Value is (lat, lng, display_city);
+# the display name lives here so the popup shows "Kraków", not Airtable's "Krakow".
+#
+# When a NEW city is confirmed and has no entry here, that institution is absent
+# from the MAP only (the build logs a warning) — it still counts in every number.
+# Add the city's coordinates here to place its pin.
+CITY_COORDS = {
+    ("dhaka", "Bangladesh"): (23.7644, 90.389, "Dhaka"),
+    ("kishoreganj", "Bangladesh"): (24.4449, 90.7766, "Kishoreganj"),
+    ("pisa", "Italy"): (43.4715, 10.6798, "Pisa"),
+    ("san josé", "Costa Rica"): (9.9328, -84.0796, "San José"),
+    ("cartago", "Costa Rica"): (9.8157, -83.6944, "Cartago"),
+    ("albuquerque", "United States"): (35.0841, -106.651, "Albuquerque"),
+    ("madison", "United States"): (40.7598, -74.4171, "Madison"),
+    ("new york city", "United States"): (40.7128, -74.006, "New York City"),
+    ("riga", "Latvia"): (56.9494, 24.1052, "Riga"),
+    ("santa cruz", "Bolivia"): (-17.7834, -63.1821, "Santa Cruz de la Sierra"),
+    ("krakow", "Poland"): (50.0619, 19.9369, "Kraków"),
+    ("białystok", "Poland"): (53.1325, 23.1688, "Białystok"),
+    ("toledo", "Spain"): (39.8559, -4.0243, "Toledo"),
+    ("madrid", "Spain"): (40.4168, -3.7035, "Madrid"),
+    ("zaragoza", "Spain"): (41.6916, -0.9101, "Zaragoza"),
+    ("huesca", "Spain"): (42.1361, -0.0298, "Huesca"),
+    ("estepona", "Spain"): (36.4268, -5.1468, "Estepona"),
+    ("salamanca", "Spain"): (40.9652, -5.664, "Salamanca"),
+    ("a coruña", "Spain"): (43.3466, -8.4127, "A Coruña"),
+    ("granada", "Spain"): (37.1773, -3.5986, "Granada"),
+    ("l'hospitalet de llobregat", "Spain"): (41.3596, 2.0999, "L'Hospitalet de Llobregat"),
+    ("kolhapur", "India"): (16.7028, 74.2405, "Kolhapur"),
+    ("kolkata", "India"): (22.5726, 88.3639, "Kolkata"),
+    ("pula", "Croatia"): (44.8702, 13.8455, "Pula"),
+    ("kampala", "Uganda"): (0.3177, 32.5814, "Kampala"),
+    ("helsinki", "Finland"): (60.1666, 24.9435, "Helsinki"),
+    ("kathmandu", "Nepal"): (27.7172, 85.324, "Kathmandu"),
+    ("tangerang selatan", "Indonesia"): (-6.2885, 106.7181, "Tangerang Selatan"),
+    ("athens", "Greece"): (37.9838, 23.7275, "Athens"),
+    ("bucharest", "Romania"): (44.4268, 26.1025, "Bucharest"),
+}
+
+
+def build_inst_markers(institutions_records, countries_lookup):
+    """Generate partner-map markers from the confirmed institutions.
+
+    Groups confirmed institutions by (city, country) into one pin each, whose
+    popup lists every institution in that city. A confirmed institution with no
+    coordinates in CITY_COORDS is skipped from the map (logged) but is unaffected
+    everywhere else, so the map is always a subset-or-equal view of the same
+    confirmed set the counts are built from.
+    """
+    by_city = {}
+    missing = set()
+    for rec in institutions_records:
+        stage = select_name(get_field_value(rec, FIELDS["institutions"]["current_stage"]))
+        if status_key(stage) != "confirmed":
+            continue
+        name = (get_field_value(rec, FIELDS["institutions"]["name"]) or "").strip()
+        city = (get_field_value(rec, FIELDS["institutions"]["city"]) or "").strip()
+        country_ids = get_field_value(rec, FIELDS["institutions"]["country"]) or []
+        country = countries_lookup[country_ids[0]]["name"] if country_ids and country_ids[0] in countries_lookup else None
+        if not name or not city or not country:
+            continue
+        coords = CITY_COORDS.get((city.lower(), country))
+        if not coords:
+            missing.add((city, country))
+            continue
+        lat, lng, display_city = coords
+        key = (display_city, country)
+        entry = by_city.setdefault(key, {"city": display_city, "country": country, "lat": lat, "lng": lng, "institutions": []})
+        entry["institutions"].append(name)
+    for city, country in sorted(missing):
+        print(f"  Partner map: no coordinates for {city}, {country} — pin omitted "
+              f"(the institution still counts). Add it to CITY_COORDS.", file=sys.stderr)
+    return list(by_city.values())
 
 
 def get_airtable_pat():
@@ -1012,7 +1064,8 @@ def main():
 
     # Replace placeholders
     data_json = json.dumps(data_blob, separators=(",", ":"), ensure_ascii=False)
-    inst_markers_json = json.dumps(INST_MARKERS, separators=(",", ":"), ensure_ascii=False)
+    inst_markers = build_inst_markers(institutions_records, countries_lookup)
+    inst_markers_json = json.dumps(inst_markers, separators=(",", ":"), ensure_ascii=False)
 
     output_content = template_content.replace("/*DATA_BLOB*/", data_json)
     output_content = output_content.replace("/*INST_MARKERS*/", inst_markers_json)

--- a/scripts/template.html
+++ b/scripts/template.html
@@ -219,11 +219,20 @@ document.querySelectorAll('.nav-item').forEach(tab => {
   const keepPct = (fb.keep && fb.keep.pct != null) ? fb.keep.pct + '%' : '—';
   const impact = (fb.ratings && fb.ratings.impact) || {};
   const rs = g.repeatSchools || {};
+  // Partner institutions: the count and the per-country breakdown come from the
+  // same confirmed set the map is built from, so all three always agree.
+  const partnerCount = g.partnerInstitutions || 0;
+  const instCountries = g.instCountries || {};
+  const countryRows = Object.entries(instCountries)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([c, n]) => `<div style="display:flex;justify-content:space-between;gap:14px;padding:7px 0;border-bottom:1px solid var(--border)"><span>${c}</span><span style="font-weight:600;color:var(--blue-ink)">${n}</span></div>`)
+    .join('');
   el.innerHTML = `
     <div class="act-label act-scale">Scale &amp; momentum</div>
     <div class="cards">
       <div class="card"><div class="num" id="ovActive">${g.activeStudents}</div><div class="lbl">Students currently in the program</div></div>
       <div class="card"><div class="num">${started}</div><div class="lbl">Students who have joined to date</div></div>
+      <div class="card"><div class="num">${partnerCount}</div><div class="lbl">Partner institutions</div></div>
       <div class="card"><div class="num">${countryCount}</div><div class="lbl">Countries</div></div>
     </div>
     <div class="chart-container">
@@ -237,6 +246,7 @@ document.querySelectorAll('.nav-item').forEach(tab => {
       <div style="position:relative;height:320px"><canvas id="growthChart"></canvas></div>
     </div>
     <div class="chart-container"><h3>Where our partners are</h3><div class="chart-sub">Partner institutions around the world</div><div id="instMap"></div></div>
+    <div class="chart-container"><h3>Partners by country</h3><div class="chart-sub">Confirmed partner institutions in each country</div><div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:2px 32px">${countryRows}</div></div>
     <div class="chart-container"><h3>Who's joining us</h3><div class="chart-sub">The academic backgrounds students bring</div><div id="fosChart"></div></div>
 
     <div class="act-label act-skills">Skills unlocked</div>


### PR DESCRIPTION
Part of #108.

Adds the two things requested, plus fixes the map they exposed.

## What's new on the Overview

In **Scale & momentum**:
- a **Partner institutions** card, next to Countries
- a **Partners by country** block under the map, listing each country's count

Both read fields the build already computed (`partnerInstitutions`, `instCountries`) from the confirmed institutions, so these were display-only.

| | |
|---|---|
| Partner institutions | **36** |
| Countries | **16** |
| Spain 12 · US 4 · India 3 · Poland 3 · Bangladesh 2 · Costa Rica 2 · … | sums to 36 |

## The map was the real work

"Where our partners are" was driven by a hand-maintained `INST_MARKERS` list that had drifted badly:

- covered **26 institutions in 12 countries** while **34** were confirmed in **15**
- missed Nepal, Greece and Indonesia entirely; undercounted Spain, US, India, Poland
- plotted *Universidad Privada Franz Tamayo* in **two** Bolivian cities — a phantom second pin

And because it was hardcoded, it re-drifted every time a partner was added. Airtable has already grown to **36 confirmed across 16 countries** since the last build, so a one-off patch would have been stale within the week.

**The map is now generated from the confirmed institutions at build time** — the same set the count and breakdown use, so all three can never disagree. `INST_MARKERS` is replaced by:

- `CITY_COORDS` — a `(lowercased city, country) → (lat, lng, display name)` table. Reuses every coordinate already verified in the old list, adds the newly-confirmed cities (Kathmandu, Athens, Bucharest, New York City, Białystok, Granada, L'Hospitalet, Tangerang Selatan, Kishoreganj).
- `build_inst_markers()` — groups confirmed institutions by city into one pin each (popup lists every institution there), resolving country via the Countries table.

**Graceful degradation:** a confirmed institution whose city isn't in `CITY_COORDS` is dropped from the **map only**, with a build-log warning, and still counts everywhere else. So the map can never show *more* than the confirmed set — only, at worst, temporarily fewer pins until a new city's coordinates are added. The headline count and per-country breakdown stay correct regardless.

## Verified against current Airtable

All 36 confirmed institutions place: **30 pins** (6 cities host 2 institutions each), **16 countries**, **zero missing coordinates**, Bolivia down to one pin. Scale cards, the by-country list (sums to 36) and the map all agree. No console errors.

**On deploy the numbers reflect live Airtable, which is actively growing** — expect 36+/16+, not the 34/15 currently on the site.

## One nuance for @peiraisotta

The count treats **CNM Ingenuity** and **Central New Mexico Community College** as 2 separate partner institutions (both confirmed, both Albuquerque), while for repeat-cohorts we alias them as one partner. It's a 1-institution difference and it's the existing `partnerInstitutions` behaviour — flagging it in case you'd rather they count as one here too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)