### PR TITLE
Map: UNIFRANZ two campuses, cluster overlapping pins, link names to sites

### DIFF
--- a/scripts/build_dashboard.py
+++ b/scripts/build_dashboard.py
@@ -85,6 +85,7 @@ FIELDS = {
         "city": "fldinUAUulxqjZ7d5",
         "country": "fldMZYV5XmC6FbewY",
         "current_stage": "fld4l5x6ScLSLaJZl",
+        "website": "fldbpCAGd36ejjkaE",
     },
     "sponsors": {
         "company_name": "fldezMq2OBVeqn0DK",
@@ -161,7 +162,43 @@ CITY_COORDS = {
     ("tangerang selatan", "Indonesia"): (-6.2885, 106.7181, "Tangerang Selatan"),
     ("athens", "Greece"): (37.9838, 23.7275, "Athens"),
     ("bucharest", "Romania"): (44.4268, 26.1025, "Bucharest"),
+    ("cochabamba", "Bolivia"): (-17.4012, -66.1676, "Cochabamba"),
+    ("udupi", "India"): (13.3409, 74.7421, "Udupi"),
+    ("kundapura", "India"): (13.6255, 74.691, "Kundapura"),
 }
+
+# Institutions that Airtable holds as a single record but that operate more than
+# one physical campus. Listed here so the map draws a pin per campus with its own
+# label; the partner-institution COUNT and per-country breakdown are unaffected —
+# it is one university, counted once, shown in two places. Keyed by the Airtable
+# name; each campus is (lowercased city, country, display label). The city must
+# have an entry in CITY_COORDS above.
+CAMPUS_OVERRIDES = {
+    "Universidad Privada Franz Tamayo (UNIFRANZ)": [
+        ("santa cruz", "Bolivia", "Universidad Privada Franz Tamayo Santa Cruz de la Sierra"),
+        ("cochabamba", "Bolivia", "Universidad Privada Franz Tamayo Cochabamba"),
+    ],
+}
+
+
+def clean_website(url):
+    """Normalise an institution website field into a usable https link, or None.
+
+    Adds a scheme when the field is a bare domain, and rejects search-engine
+    redirect junk (some records hold a Bing/Google "click" URL instead of the
+    real site) so those show as plain text rather than a broken-looking link.
+    """
+    if not url:
+        return None
+    url = url.strip()
+    if not url:
+        return None
+    low = url.lower()
+    if "bing.com/ck" in low or "google.com/url" in low or "/ck/a" in low:
+        return None
+    if not low.startswith(("http://", "https://")):
+        url = "https://" + url
+    return url
 
 
 def build_inst_markers(institutions_records, countries_lookup):
@@ -175,24 +212,45 @@ def build_inst_markers(institutions_records, countries_lookup):
     """
     by_city = {}
     missing = set()
+
+    def place(display_city, country, lat, lng, inst_name, url):
+        entry = by_city.setdefault((display_city, country),
+                                   {"city": display_city, "country": country, "lat": lat, "lng": lng, "institutions": []})
+        entry["institutions"].append({"name": inst_name, "url": url})
+
     for rec in institutions_records:
         stage = select_name(get_field_value(rec, FIELDS["institutions"]["current_stage"]))
         if status_key(stage) != "confirmed":
             continue
         name = (get_field_value(rec, FIELDS["institutions"]["name"]) or "").strip()
-        city = (get_field_value(rec, FIELDS["institutions"]["city"]) or "").strip()
         country_ids = get_field_value(rec, FIELDS["institutions"]["country"]) or []
         country = countries_lookup[country_ids[0]]["name"] if country_ids and country_ids[0] in countries_lookup else None
-        if not name or not city or not country:
+        if not name or not country:
+            continue
+        url = clean_website(get_field_value(rec, FIELDS["institutions"]["website"]))
+
+        # Multi-campus institution: one pin per campus, with its own label.
+        campuses = CAMPUS_OVERRIDES.get(name)
+        if campuses:
+            for city_key, campus_country, label in campuses:
+                coords = CITY_COORDS.get((city_key, campus_country))
+                if not coords:
+                    missing.add((city_key.title(), campus_country))
+                    continue
+                lat, lng, display_city = coords
+                place(display_city, campus_country, lat, lng, label, url)
+            continue
+
+        city = (get_field_value(rec, FIELDS["institutions"]["city"]) or "").strip()
+        if not city:
             continue
         coords = CITY_COORDS.get((city.lower(), country))
         if not coords:
             missing.add((city, country))
             continue
         lat, lng, display_city = coords
-        key = (display_city, country)
-        entry = by_city.setdefault(key, {"city": display_city, "country": country, "lat": lat, "lng": lng, "institutions": []})
-        entry["institutions"].append(name)
+        place(display_city, country, lat, lng, name, url)
+
     for city, country in sorted(missing):
         print(f"  Partner map: no coordinates for {city}, {country} — pin omitted "
               f"(the institution still counts). Add it to CITY_COORDS.", file=sys.stderr)

--- a/scripts/template.html
+++ b/scripts/template.html
@@ -14,7 +14,10 @@
 <meta name="twitter:title" content="WordPress Credits Dashboard">
 <meta name="twitter:description" content="Live dashboard tracking WordPress Credits program: students, mentors, institutions, contributions, and translation activity.">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.5.3/MarkerCluster.css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.5.3/MarkerCluster.Default.css"/>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.5.3/leaflet.markercluster.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.js"></script>
 <style>
 @import url('https://fonts.googleapis.com/css2?family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600&family=Inter:wght@400;500;600&display=swap');
@@ -83,6 +86,12 @@ h1,h2,h3,h4{font-family:var(--serif);font-weight:600}
 .leaflet-popup-content h4{margin:0 0 6px;font-size:14px;color:var(--wp-blue);border-bottom:1px solid var(--border);padding-bottom:4px}
 .leaflet-popup-content ul{margin:0;padding:0 0 0 16px}
 .leaflet-popup-content li{margin:2px 0;color:var(--text)}
+.leaflet-popup-content a{color:var(--wp-blue);text-decoration:none}
+.leaflet-popup-content a:hover{text-decoration:underline}
+/* Recolour marker clusters from the plugin's default green/amber to the WP-blue
+   palette so they read as part of the same map as the individual pins. */
+.marker-cluster{background:rgba(56,88,233,.22)}
+.marker-cluster div{background:var(--wp-blue);color:#fff;font-family:var(--sans);font-weight:700}
 .footer{text-align:center;padding:22px;color:var(--text-light);font-size:12px}
 .sponsors{border-top:1px solid var(--border);margin-top:8px;padding:30px 24px;text-align:center}
 .sponsors-label{font-size:13px;color:var(--text-light);margin-bottom:18px;letter-spacing:.02em}
@@ -162,14 +171,23 @@ function initInstMap() {
     });
   };
 
+  // Cluster nearby pins: partner cities are often only a few km apart (San José
+  // and Cartago, or the ten Spanish cities), so at world zoom they would sit on
+  // top of each other and hide one another. Clustering keeps every institution
+  // reachable and shows partner density.
+  const cluster = L.markerClusterGroup({ maxClusterRadius: 45, showCoverageOnHover: false });
   INST_MARKERS.forEach(m => {
     const icon = m.institutions.length > 1 ? wpIconMulti(m.institutions.length) : wpIcon;
-    const list = m.institutions.map(n => '<li>' + n + '</li>').join('');
+    const list = m.institutions.map(inst => {
+      const label = inst.url
+        ? '<a href="' + inst.url + '" target="_blank" rel="noopener noreferrer">' + inst.name + '</a>'
+        : inst.name;
+      return '<li>' + label + '</li>';
+    }).join('');
     const popup = '<h4>' + m.city + ', ' + m.country + '</h4><ul>' + list + '</ul>';
-    L.marker([m.lat, m.lng], { icon: icon })
-      .addTo(map)
-      .bindPopup(popup, { maxWidth: 280 });
+    cluster.addLayer(L.marker([m.lat, m.lng], { icon: icon }).bindPopup(popup, { maxWidth: 280 }));
   });
+  map.addLayer(cluster);
 
   // Invalidate size when tab becomes visible
   const observer = new MutationObserver(() => {


### PR DESCRIPTION
Part of #108. Three partner-map fixes you flagged.

## 1. UNIFRANZ's Cochabamba campus is back

The old hand-made map had two UNIFRANZ pins (Santa Cruz + Cochabamba); making the map data-driven last week collapsed it to the single Airtable record (Santa Cruz only). Restored via a new `CAMPUS_OVERRIDES` table — for a university Airtable holds as one record but that runs more than one physical campus. Both pins relabelled as you asked:

- **Universidad Privada Franz Tamayo Santa Cruz de la Sierra**
- **Universidad Privada Franz Tamayo Cochabamba**

**It stays one partner institution** in the count and the per-country breakdown (one university), drawn in two places on the map. So Bolivia reads "1" in the breakdown but shows two campus pins — flag me if you'd rather it count as 2.

## 2. Fidélitas wasn't missing — it was hidden

Its San José pin is ~22 km from Cartago, so at the opening world-zoom the two overlapped and one covered the other. The ten Spanish cities did the same, so the map was quietly hiding most of its pins.

**Added marker clustering** (Leaflet.markercluster): overlapping pins become a numbered bubble that expands on click or zoom, so every institution is reachable and partner density shows at a glance. Clusters recoloured from the plugin's default green/amber to WP-blue. This is a visible change to the map's look — numbered clusters instead of a blob.

## 3. Popup names now link to each school's website

From the institutions "website" field. A bare domain gets `https://`; a couple of records hold a Bing search-redirect instead of the real site, which is rejected so those show as plain text; institutions with no website (Pisa, Fidélitas) also show plain.

## Also

Added coordinates for **Udupi** and **Kundapura** (India) — two institutions confirmed since this morning's build — so they land on the map rather than logging a missing-coordinate warning.

## Verified

Against the current **38 confirmed** institutions: 33 pins, UNIFRANZ shows both campuses, Fidélitas reachable via its Costa Rica cluster, 36 of 39 map entries linked (Bing/no-website ones plain), clusters render in blue, no console errors. Count/breakdown unaffected: 38 institutions across 16 countries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)