### PR TITLE
Start the growth chart at the program's first cohort (Sept 2025)

### DIFF
--- a/scripts/build_dashboard.py
+++ b/scripts/build_dashboard.py
@@ -971,7 +971,15 @@ def main():
             if mk and mk <= current_month:
                 graduated_by_month[mk] = graduated_by_month.get(mk, 0) + 1
 
-    # Continuous monthly series from first activity through the current month,
+    # The program's first cohort started in September 2025. A single earlier,
+    # mis-dated record would otherwise stretch the timeline back across ~two empty
+    # years, so the growth chart begins at the program start and the cumulative
+    # line counts from there.
+    PROGRAM_START_MONTH = "2025-09"
+    joined_by_month = {k: v for k, v in joined_by_month.items() if k >= PROGRAM_START_MONTH}
+    graduated_by_month = {k: v for k, v in graduated_by_month.items() if k >= PROGRAM_START_MONTH}
+
+    # Continuous monthly series from the program start through the current month,
     # filling empty months with zeros so the timeline has no gaps.
     growth = {"months": [], "joined": [], "graduated": [], "cumulativeJoined": []}
     all_months = set(joined_by_month) | set(graduated_by_month)


### PR DESCRIPTION
Part of #108.

The "How the program is growing" chart began at the earliest dated record — a **single mis-dated join in July 2023** — which stretched the x-axis back across ~26 empty months before any real activity. The actual growth story (Sept 2025 onward) was crammed into the right third of the chart.

**Fix:** clamp the growth series to start at `PROGRAM_START_MONTH` (2025-09), the first real cohort, and count the cumulative line from there. The chart now spans 11 months of real activity, September 2025 → current month, bars filling the full width.

**Growth-chart only.** The headline totals (students joined to date = 566, graduates, etc.) come from separate status-based counts and are unaffected — the stray early record still counts there, it just no longer anchors the chart's axis.

Verified against live data: series is now `2025-09 … 2026-07` (11 months), joined `[3,20,35,1,14,93,46,16,257,6,60]`, cumulative starts fresh at 3, chart renders full-width with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)