### PR TITLE
Quick copy wins: Testimonials, Who's joined us, graduated caption, drop repeat-cohorts

### DIFF
--- a/scripts/template.html
+++ b/scripts/template.html
@@ -115,7 +115,7 @@ h1,h2,h3,h4{font-family:var(--serif);font-weight:600}
 </header>
 <div class="nav" id="mainNav">
   <div class="nav-item active" data-section="global">Overview</div>
-  <div class="nav-item" data-section="feedback">Voices</div>
+  <div class="nav-item" data-section="feedback">Testimonials</div>
 </div>
 <div class="content">
   <div class="section active" id="sec-global"></div>
@@ -236,7 +236,6 @@ document.querySelectorAll('.nav-item').forEach(tab => {
   const recPct = (fb.recommend && fb.recommend.pct != null) ? fb.recommend.pct + '%' : '—';
   const keepPct = (fb.keep && fb.keep.pct != null) ? fb.keep.pct + '%' : '—';
   const impact = (fb.ratings && fb.ratings.impact) || {};
-  const rs = g.repeatSchools || {};
   // Partner institutions: the count and the per-country breakdown come from the
   // same confirmed set the map is built from, so all three always agree.
   const partnerCount = g.partnerInstitutions || 0;
@@ -265,7 +264,7 @@ document.querySelectorAll('.nav-item').forEach(tab => {
     </div>
     <div class="chart-container"><h3>Where our partners are</h3><div class="chart-sub">Partner institutions around the world</div><div id="instMap"></div></div>
     <div class="chart-container"><h3>Partners by country</h3><div class="chart-sub">Confirmed partner institutions in each country</div><div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:2px 32px">${countryRows}</div></div>
-    <div class="chart-container"><h3>Who's joining us</h3><div class="chart-sub">The academic backgrounds students bring</div><div id="fosChart"></div></div>
+    <div class="chart-container"><h3>Who's joined us</h3><div class="chart-sub">The academic backgrounds students bring</div><div id="fosChart"></div></div>
 
     <div class="act-label act-skills">Skills unlocked</div>
     <div class="chart-container">
@@ -302,13 +301,13 @@ document.querySelectorAll('.nav-item').forEach(tab => {
     </div>
 
     <div class="act-label act-outcomes">Outcomes &amp; quality</div>
+    <p class="chart-sub" style="margin:-6px 0 16px;max-width:760px">A graduate is a student who completed their agreed hours of applied, real-world work in the WordPress open source project — ranging from 50 to 400 hours — as part of their studies.</p>
     <div class="cards cards-outcomes">
       <div class="card hl"><div class="num">${completionRate != null ? completionRate + '%' : '—'}</div><div class="lbl">Graduated from the program</div></div>
       <div class="card"><div class="num">${grad}</div><div class="lbl">Graduates to date</div></div>
       <div class="card"><div class="num">${impact.avg != null ? impact.avg + '<span style="font-size:20px;color:var(--text-light)">/5</span>' : '—'}</div><div class="lbl">How impactful graduates rate their contributions</div></div>
       <div class="card"><div class="num">${recPct}</div><div class="lbl">Graduates who would recommend the program</div></div>
       <div class="card"><div class="num">${keepPct}</div><div class="lbl">Graduates who plan to keep contributing to WordPress</div></div>
-      <div class="card"><div class="num">${rs.pct != null ? rs.pct + '%' : '—'}</div><div class="lbl">Schools that have run more than one cohort</div>${rs.total ? `<div class="act-sub">of the ${rs.total} schools with us long enough to return</div>` : ''}</div>
     </div>
   `;
   // Growth over time (joining vs graduating, by month)
@@ -378,7 +377,7 @@ document.querySelectorAll('.nav-item').forEach(tab => {
   ];
   var voicesHtml = voices.map(function(v){ return '<div class="voice"><div class="voice-q">“'+v.q+'”</div><div class="voice-meta"><span>'+v.who+'</span><span class="voice-tag"><span aria-hidden="true">'+flag(v.cc)+'</span> '+v.country+'</span></div></div>'; }).join('');
   el.innerHTML = ''
-    + '<h3 style="font-size:18px;margin:4px 0 6px">Voices from the program</h3>'
+    + '<h3 style="font-size:18px;margin:4px 0 6px">Student testimonials</h3>'
     + '<p style="font-size:13px;color:var(--text-light);margin:0 0 18px">In students’ own words, shared with their consent.</p>'
     + '<div class="voices-grid">' + voicesHtml + '</div>';
 })();


### PR DESCRIPTION
Part of #108. The approved quick wins from the feedback round. Template-only.

- **"Voices" → "Testimonials"** (tab), with section heading **"Student testimonials"**.
- **"Who's joining us" → "Who's joined us"**.
- **Definition of "graduated"** added under Outcomes & quality, for external readers: *"A graduate is a student who completed their agreed hours of applied, real-world work in the WordPress open source project — ranging from 50 to 400 hours — as part of their studies."*
- **Removed "Schools that have run more than one cohort"** — not a strong enough number yet. The build still computes `repeatSchools`, so it's cheap to restore; only the card is dropped.

Verified against live data: Outcomes shows 5 cards, tabs read Overview · Testimonials, graduated note renders, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)