### PR TITLE
Skills: add a short description to each chip (hover, focus, tap)

### DIFF
--- a/scripts/template.html
+++ b/scripts/template.html
@@ -52,7 +52,6 @@ h1,h2,h3,h4{font-family:var(--serif);font-weight:600}
 .card{background:var(--card-bg);border-radius:var(--radius);box-shadow:var(--shadow);padding:19px 22px}
 .card .num{font-family:var(--serif);font-size:34px;font-weight:600;color:var(--blue-ink);line-height:1.05}
 .card .lbl{font-size:12px;color:var(--text-light);margin-top:7px;letter-spacing:.01em}
-.card .act-sub{font-size:12px;color:var(--wp-green);margin-top:6px;font-weight:500}
 /* Outcomes uses a fixed 3-up grid so the six cards read as two even rows and the
    longer, self-explanatory labels have room to breathe. */
 .cards-outcomes{grid-template-columns:repeat(3,1fr)}
@@ -61,7 +60,6 @@ h1,h2,h3,h4{font-family:var(--serif);font-weight:600}
 .cards-outcomes .lbl{font-size:13px;line-height:1.4;color:var(--text)}
 .card.hl{background:var(--amber-tint)}
 .card.hl .num{color:var(--wp-orange)}
-.card.hl .act-sub{color:var(--wp-orange)}
 .chart-container{background:var(--card-bg);border-radius:var(--radius);box-shadow:var(--shadow);padding:22px 24px;margin-bottom:20px}
 .chart-container h3{font-size:18px;margin-bottom:3px;color:var(--text)}
 .chart-sub{font-size:13px;color:var(--text-light);margin:0 0 16px;line-height:1.4}
@@ -79,8 +77,13 @@ h1,h2,h3,h4{font-family:var(--serif);font-weight:600}
 @media(max-width:760px){.skills-grid{grid-template-columns:1fr}}
 .skills-head{font-size:12px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--text-light);margin-bottom:12px}
 .skills-chips{display:flex;flex-wrap:wrap;gap:8px}
-.skill{display:inline-block;padding:7px 14px;border-radius:20px;font-size:13px;font-weight:500;background:var(--blue-tint);color:var(--blue-ink)}
+.skill{display:inline-block;padding:7px 14px;border-radius:20px;font-size:13px;font-weight:500;background:var(--blue-tint);color:var(--blue-ink);position:relative;cursor:pointer}
 .skills-transferable .skill{background:var(--green-tint);color:#1F5C43}
+/* Each skill chip carries a short description shown on hover, keyboard focus, or
+   tap (the .show class is toggled by a delegated click handler so touch works). */
+.skill .tip{position:absolute;left:0;bottom:calc(100% + 9px);z-index:30;width:250px;max-width:76vw;background:var(--text);color:#fff;font-size:12px;font-weight:400;line-height:1.45;padding:9px 11px;border-radius:9px;box-shadow:0 4px 16px rgba(45,32,12,.24);opacity:0;visibility:hidden;transform:translateY(3px);transition:opacity .12s,transform .12s;pointer-events:none}
+.skill .tip::after{content:"";position:absolute;top:100%;left:20px;border:6px solid transparent;border-top-color:var(--text)}
+.skill:hover .tip,.skill:focus-visible .tip,.skill.show .tip{opacity:1;visibility:visible;transform:translateY(0)}
 #instMap{width:100%;height:460px;border-radius:var(--radius);z-index:1}
 .leaflet-popup-content{font-family:var(--sans);font-size:13px;line-height:1.6}
 .leaflet-popup-content h4{margin:0 0 6px;font-size:14px;color:var(--wp-blue);border-bottom:1px solid var(--border);padding-bottom:4px}
@@ -268,26 +271,26 @@ document.querySelectorAll('.nav-item').forEach(tab => {
 
     <div class="act-label act-skills">Skills unlocked</div>
     <div class="chart-container">
-      <div class="chart-sub" style="margin-bottom:18px">Technical and transferable skills students build through real open-source work.</div>
+      <div class="chart-sub" style="margin-bottom:18px">Technical and transferable skills students build through real open-source work. <span style="color:var(--text-light)">Hover or tap a skill for a short description.</span></div>
       <div class="skills-grid">
         <div>
           <div class="skills-head">Technical</div>
           <div class="skills-chips">
-            <span class="skill">Website building &amp; customization</span>
-            <span class="skill">Localization &amp; translation</span>
-            <span class="skill">Design &amp; visual media</span>
-            <span class="skill">Content &amp; documentation</span>
-            <span class="skill">Quality, testing &amp; accessibility</span>
+            <span class="skill" tabindex="0">Website building &amp; customization<span class="tip">Building and customizing real WordPress sites, from themes and blocks to layouts, so students leave able to ship a working website end to end.</span></span>
+            <span class="skill" tabindex="0">Localization &amp; translation<span class="tip">Translating and reviewing WordPress core, themes, and plugins into local languages, making the software usable for their own communities.</span></span>
+            <span class="skill" tabindex="0">Design &amp; visual media<span class="tip">Creating and curating visual assets, from the Photo Directory to design contributions, with an eye for consistency and reuse.</span></span>
+            <span class="skill" tabindex="0">Content &amp; documentation<span class="tip">Writing and improving documentation and help content so that what they learn is easier for the next person to pick up.</span></span>
+            <span class="skill" tabindex="0">Quality, testing &amp; accessibility<span class="tip">Testing features, reporting issues, and checking that what ships works for everyone, including people who rely on assistive technology.</span></span>
           </div>
         </div>
         <div class="skills-transferable">
           <div class="skills-head">Transferable</div>
           <div class="skills-chips">
-            <span class="skill">Open-source collaboration, tools &amp; workflow</span>
-            <span class="skill">Professional communication</span>
-            <span class="skill">Project &amp; time management</span>
-            <span class="skill">Giving &amp; receiving feedback</span>
-            <span class="skill">Public speaking &amp; community participation</span>
+            <span class="skill" tabindex="0">Open-source collaboration, tools &amp; workflow<span class="tip">Working the way open-source teams do: version control, issue trackers, and public contribution workflows, alongside contributors around the world.</span></span>
+            <span class="skill" tabindex="0">Professional communication<span class="tip">Communicating clearly and professionally in a distributed, asynchronous team, in writing and across cultures.</span></span>
+            <span class="skill" tabindex="0">Project &amp; time management<span class="tip">Planning their own work, tracking progress, and meeting commitments across the program's required hours.</span></span>
+            <span class="skill" tabindex="0">Giving &amp; receiving feedback<span class="tip">Giving and acting on constructive feedback through reviews and mentorship, a core habit of open-source work.</span></span>
+            <span class="skill" tabindex="0">Public speaking &amp; community participation<span class="tip">Taking part in the wider WordPress community, from meetups and events to contributor days, and finding their voice in it.</span></span>
           </div>
         </div>
       </div>
@@ -381,6 +384,14 @@ document.querySelectorAll('.nav-item').forEach(tab => {
     + '<p style="font-size:13px;color:var(--text-light);margin:0 0 18px">In students’ own words, shared with their consent.</p>'
     + '<div class="voices-grid">' + voicesHtml + '</div>';
 })();
+
+// Skill chips: tap toggles the description (hover and keyboard focus cover desktop).
+// Delegated so it works regardless of when the Overview renders its chips.
+document.addEventListener('click', function(e){
+  var chip = e.target.closest ? e.target.closest('.skill') : null;
+  document.querySelectorAll('.skill.show').forEach(function(s){ if(s !== chip) s.classList.remove('show'); });
+  if(chip){ chip.classList.toggle('show'); e.stopPropagation(); }
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
Part of #108. Template-only.

A reviewer asked what the skill tags actually mean. Each chip now carries a one-to-two sentence description, shown on **hover, keyboard focus, and tap**. Tap works via a small delegated click handler (touch has no hover), and only one description is open at a time. A line in the section sub tells people the chips are interactive.

**Localization & translation** now reads "WordPress **core, themes, and plugins**" rather than just "WordPress", per Isotta. Tool names are intentionally left out for now, to be added once the list is confirmed.

Also removed the `.act-sub` CSS, orphaned when the repeat-cohorts card went in #169.

Verified: all 10 chips have tooltips; hover / focus / tap all reveal them; tapping one closes the others; no console errors; no dead CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)