### PR TITLE
Testimonials: add "What students say they gained" themes above the quotes

### DIFF
--- a/scripts/template.html
+++ b/scripts/template.html
@@ -108,6 +108,12 @@ h1,h2,h3,h4{font-family:var(--serif);font-weight:600}
 .voice-q{font-family:var(--serif);font-size:16px;line-height:1.55;color:var(--text)}
 .voice-meta{margin-top:14px;display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-size:12.5px;color:var(--text-light)}
 .voice-tag{display:inline-flex;align-items:center;gap:5px;border:1px solid var(--border);border-radius:5px;padding:2px 7px;font-size:11px;white-space:nowrap}
+.gained-row{display:flex;align-items:center;gap:14px;margin:13px 0}
+.gained-label{flex:0 0 38%;font-size:13.5px;color:var(--text);font-weight:500}
+.gained-track{flex:1;height:12px;border-radius:6px;background:var(--blue-tint);overflow:hidden}
+.gained-fill{height:100%;border-radius:6px;background:var(--blue-ink)}
+.gained-pct{flex:0 0 auto;min-width:40px;text-align:right;font-family:var(--serif);font-size:17px;font-weight:600;color:var(--blue-ink)}
+@media(max-width:560px){.gained-row{flex-wrap:wrap;gap:6px}.gained-label{flex-basis:100%}.gained-pct{min-width:0}}
 @media(max-width:768px){.nav-item{padding:10px 12px;font-size:13px}.site-header{padding:22px 18px 16px}.nav{padding:0 18px}.content{padding:8px 18px 20px}}
 </style>
 </head>
@@ -379,6 +385,13 @@ document.querySelectorAll('.nav-item').forEach(tab => {
   el.innerHTML = ''
     + '<h3 style="font-size:18px;margin:4px 0 6px">Student testimonials</h3>'
     + '<p style="font-size:13px;color:var(--text-light);margin:0 0 18px">In students’ own words, shared with their consent.</p>'
+    + '<div class="chart-container" style="margin-bottom:16px">'
+    +   '<h3>What students say they gained</h3>'
+    +   '<div class="chart-sub">Share of students who mentioned each, in their own words. Students often name several, so these don’t add up to 100%.</div>'
+    +   '<div class="gained-row"><div class="gained-label">Technical &amp; web-building skills</div><div class="gained-track"><div class="gained-fill" style="width:81%"></div></div><div class="gained-pct">81%</div></div>'
+    +   '<div class="gained-row"><div class="gained-label">Hands-on learning by doing</div><div class="gained-track"><div class="gained-fill" style="width:72%"></div></div><div class="gained-pct">72%</div></div>'
+    +   '<p style="font-size:12px;color:var(--text-light);margin-top:16px">Based on 177 students who described their experience in their own words.</p>'
+    + '</div>'
     + '<div class="voices-grid">' + voicesHtml + '</div>';
 })();
 


### PR DESCRIPTION
Part of #108. Template-only.

Adds an honest aggregate above the testimonials, from Isotta's #123 open-text analysis, so the tab isn't pure anecdote for sponsors.

**What students say they gained** (bars, above the quotes):

| | |
|---|---|
| Technical & web-building skills | 81% |
| Hands-on learning by doing | 72% |

### Kept honest

The coding overlaps (a student can mention several themes), so:
- caption: *"Share of students who mentioned each, in their own words. Students often name several, so these don't add up to 100%."*
- footnote: *"Based on 177 students who described their experience in their own words."*
- shown as **bars, never a pie or split**, so the overlap can't be misread.

Isotta chose the two cleanest, highest-signal themes. The more confounded ones were left out on purpose — e.g. translation (49%) mostly reflects *what students worked on*, since Polyglots is the largest team, not what they valued.

Verified: block renders above the six quotes, bars at 81% / 72%, JS passes a clean syntax check, no new console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)