### PR TITLE
Add a "what contributions are" caption to What students produce

### DIFF
--- a/scripts/template.html
+++ b/scripts/template.html
@@ -301,6 +301,7 @@ document.querySelectorAll('.nav-item').forEach(tab => {
     </div>
 
     <div class="act-label act-produce">What students produce</div>
+    <p class="chart-sub" style="margin:-6px 0 16px;max-width:760px">Contributions are the hands-on work students do on the WordPress open source project — code, design, translation, workshop facilitation, photos, documentation, testing, and more — organised through its official contribution teams.</p>
     <div class="cards">
       <div class="card"><div class="num">${(g.firstContributions || 0).toLocaleString()}</div><div class="lbl">First contributions made</div></div>
       <div class="card"><div class="num">${(g.sitesCreated || 0).toLocaleString()}</div><div class="lbl">WordPress sites created</div></div>


### PR DESCRIPTION
Part of #108. Template-only.

Mirrors the graduated-definition caption under Outcomes & quality, so external readers know what "contributions" and "contribution teams" mean. Wording by Isotta:

> Contributions are the hands-on work students do on the WordPress open source project — code, design, translation, workshop facilitation, photos, documentation, testing, and more — organised through its official contribution teams.

Sits under the "What students produce" label, above the three cards, in the same muted caption style. Verified: renders correctly, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)