### PR TITLE
Skills unlocked: move the intro above the card, matching the other sections

### DIFF
--- a/scripts/template.html
+++ b/scripts/template.html
@@ -274,8 +274,8 @@ document.querySelectorAll('.nav-item').forEach(tab => {
     <div class="chart-container"><h3>Who's joined us</h3><div class="chart-sub">The academic backgrounds students bring</div><div id="fosChart"></div></div>
 
     <div class="act-label act-skills">Skills unlocked</div>
+    <p class="chart-sub" style="margin:-6px 0 16px;max-width:760px">Technical and transferable skills students build through real open-source work. Hover or tap a skill for a short description.</p>
     <div class="chart-container">
-      <div class="chart-sub" style="margin-bottom:18px">Technical and transferable skills students build through real open-source work. <span style="color:var(--text-light)">Hover or tap a skill for a short description.</span></div>
       <div class="skills-grid">
         <div>
           <div class="skills-head">Technical</div>


### PR DESCRIPTION
Part of #108. Template-only.

The "Skills unlocked" intro ("Technical and transferable skills... Hover or tap a skill for a short description.") sat *inside* the white card. Moved it out to sit under the label as a caption, so Skills follows the same pattern as **What students produce** and **Outcomes & quality**: label → caption → content. The card now holds just the chips.

Text and the hover/tap tooltips are unchanged. Verified: caption sits between the label and the card, chips and tooltips still work, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)