### PR TITLE
Add the partner-network growth chart, from real "Confirmed on" dates

### DIFF
--- a/scripts/build_dashboard.py
+++ b/scripts/build_dashboard.py
@@ -86,6 +86,7 @@ FIELDS = {
         "country": "fldMZYV5XmC6FbewY",
         "current_stage": "fld4l5x6ScLSLaJZl",
         "website": "fldbpCAGd36ejjkaE",
+        "confirmed_on": "fldBANuJmJOBRQFs8",
     },
     "sponsors": {
         "company_name": "fldezMq2OBVeqn0DK",
@@ -997,6 +998,41 @@ def main():
             m = m + 1 if m < 12 else 1
             y = y if m != 1 else y + 1
 
+    # --- Partner network growth (cumulative confirmed institutions by month) ---
+    # Uses each institution's real "Confirmed on" date (falling back to the
+    # record's createdTime if it's ever empty), aligned to the same
+    # PROGRAM_START_MONTH as the student chart. Partners confirmed before launch
+    # are counted into the starting cumulative (founding partners), not dropped.
+    inst_added_by_month = {}
+    inst_pre_floor = 0
+    for rec in institutions_records:
+        stage = select_name(get_field_value(rec, FIELDS["institutions"]["current_stage"]))
+        if status_key(stage) != "confirmed":
+            continue
+        cdate = (parse_iso_date(get_field_value(rec, FIELDS["institutions"]["confirmed_on"]))
+                 or parse_iso_date(rec.get("createdTime")))
+        if not cdate:
+            continue
+        cmk = month_key(cdate)
+        if cmk < PROGRAM_START_MONTH:
+            inst_pre_floor += 1
+        else:
+            inst_added_by_month[cmk] = inst_added_by_month.get(cmk, 0) + 1
+
+    inst_growth = {"months": [], "added": [], "cumulative": []}
+    if inst_added_by_month or inst_pre_floor:
+        y, m = int(PROGRAM_START_MONTH[:4]), int(PROGRAM_START_MONTH[5:7])
+        cy, cm = int(current_month[:4]), int(current_month[5:7])
+        cum = inst_pre_floor
+        while (y, m) <= (cy, cm):
+            mk = f"{y:04d}-{m:02d}"
+            cum += inst_added_by_month.get(mk, 0)
+            inst_growth["months"].append(mk)
+            inst_growth["added"].append(inst_added_by_month.get(mk, 0))
+            inst_growth["cumulative"].append(cum)
+            m = m + 1 if m < 12 else 1
+            y = y if m != 1 else y + 1
+
     # --- Student feedback (aggregate, experience-only; no individuals) ---
     def _rating_avg(field):
         vals = [get_field_value(r, FIELDS["feedback"][field]) for r in feedback_records]
@@ -1121,6 +1157,7 @@ def main():
         "global": global_stats,
         "translationTotals": translation_totals,
         "growth": growth,
+        "instGrowth": inst_growth,
         "feedback": feedback,
         "students": public_students,
     }

--- a/scripts/template.html
+++ b/scripts/template.html
@@ -269,6 +269,15 @@ document.querySelectorAll('.nav-item').forEach(tab => {
       </div>
       <div style="position:relative;height:320px"><canvas id="growthChart"></canvas></div>
     </div>
+    <div class="chart-container">
+      <h3>How our partner network is growing</h3>
+      <div class="chart-sub">Confirmed partner institutions, month by month</div>
+      <div style="display:flex;flex-wrap:wrap;gap:16px;margin-bottom:8px;font-size:12px;color:var(--text-light)">
+        <span style="display:flex;align-items:center;gap:5px"><span style="width:10px;height:10px;border-radius:2px;background:#2A7B8C"></span>Confirmed this month</span>
+        <span style="display:flex;align-items:center;gap:5px"><span style="width:14px;height:3px;background:#3858E9;display:inline-block"></span>Total institutions</span>
+      </div>
+      <div style="position:relative;height:260px"><canvas id="instGrowthChart"></canvas></div>
+    </div>
     <div class="chart-container"><h3>Where our partners are</h3><div class="chart-sub">Partner institutions around the world</div><div id="instMap"></div></div>
     <div class="chart-container"><h3>Partners by country</h3><div class="chart-sub">Confirmed partner institutions in each country</div><div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:2px 32px">${countryRows}</div></div>
     <div class="chart-container"><h3>Who's joined us</h3><div class="chart-sub">The academic backgrounds students bring</div><div id="fosChart"></div></div>
@@ -325,6 +334,20 @@ document.querySelectorAll('.nav-item').forEach(tab => {
       data: { labels: gr.months, datasets: [
         { type:'bar', label:'Joined this month', data:gr.joined, backgroundColor:'#2F7D5B' },
         { type:'line', label:'Total students', data:gr.cumulativeJoined, borderColor:'#B07A22', backgroundColor:'#B07A22', borderWidth:2, tension:0.3, pointRadius:2 }
+      ]},
+      options: { responsive:true, maintainAspectRatio:false, plugins:{ legend:{ display:false } },
+        scales:{ x:{ grid:{ display:false }, ticks:{ autoSkip:true, maxRotation:45, minRotation:45 } },
+          y:{ beginAtZero:true } } }
+    });
+  })();
+  // Partner network growth (confirmed institutions per month + running total)
+  (function(){
+    var ig = D.instGrowth, cv = document.getElementById('instGrowthChart');
+    if (!ig || !cv || !ig.months || !ig.months.length || typeof Chart === 'undefined') return;
+    new Chart(cv, {
+      data: { labels: ig.months, datasets: [
+        { type:'bar', label:'Confirmed this month', data:ig.added, backgroundColor:'#2A7B8C' },
+        { type:'line', label:'Total institutions', data:ig.cumulative, borderColor:'#3858E9', backgroundColor:'#3858E9', borderWidth:2, tension:0.3, pointRadius:2 }
       ]},
       options: { responsive:true, maintainAspectRatio:false, plugins:{ legend:{ display:false } },
         scales:{ x:{ grid:{ display:false }, ticks:{ autoSkip:true, maxRotation:45, minRotation:45 } },


### PR DESCRIPTION
Part of #108. 

We added a **"Confirmed on"** date field to the Institutions table and backfilled every confirmed partner, so the chart uses real confirmation dates rather than the record-creation proxy.

**Build:** maps the field (`fldBANuJmJOBRQFs8`) and computes `instGrowth` — cumulative confirmed institutions by "Confirmed on" month, aligned to the same `PROGRAM_START_MONTH` as the student chart. Partners confirmed before launch count into the starting cumulative (founding partners), not dropped. Falls back to record `createdTime` if the field is ever empty (currently 100% filled).

**Template:** a **"How our partner network is growing"** chart right after the student growth chart — teal "Confirmed this month" bars + blue "Total institutions" line, one clean axis, slightly shorter (260px) so it reads as the secondary of the two growth charts.

**Verified** against the real dates: 2 founding partners rising to 39 across Sept 2025 → Aug 2026, bars + line span full width, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)