### PR TITLE
Add Bogura, Bangladesh to the partner-map coordinates

### DIFF
--- a/scripts/build_dashboard.py
+++ b/scripts/build_dashboard.py
@@ -135,6 +135,7 @@ FIELDS = {
 CITY_COORDS = {
     ("dhaka", "Bangladesh"): (23.7644, 90.389, "Dhaka"),
     ("kishoreganj", "Bangladesh"): (24.4449, 90.7766, "Kishoreganj"),
+    ("bogura", "Bangladesh"): (24.8481, 89.3728, "Bogura"),
     ("pisa", "Italy"): (43.4715, 10.6798, "Pisa"),
     ("san josé", "Costa Rica"): (9.9328, -84.0796, "San José"),
     ("cartago", "Costa Rica"): (9.8157, -83.6944, "Cartago"),


### PR DESCRIPTION
Part of #108. Build-only, one line.

Pundra University of Science & Technology (Bogura) was confirmed, but Bogura wasn't in `CITY_COORDS`, so the build logged `no coordinates for Bogura` and dropped its map pin (it still counted in the totals and per-country breakdown). Adds the city so the pin shows; the map now represents every confirmed institution.

Verified the marker resolves via `build_inst_markers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)